### PR TITLE
Add numba_pandas extension

### DIFF
--- a/hpat/__init__.py
+++ b/hpat/__init__.py
@@ -35,3 +35,12 @@ multithread_mode = False
 
 __version__ = get_versions()['version']
 del get_versions
+
+
+def _init_extension():
+    '''Register Pandas classes and functions with Numba.
+
+    This exntry_point is called by Numba when it initializes.
+    '''
+    # Importing SDC is already happened
+    pass

--- a/setup.py
+++ b/setup.py
@@ -528,4 +528,10 @@ setup(name='hpat',
       install_requires=['numba'],
       extras_require={'HDF5': ["h5py"], 'Parquet': ["pyarrow"]},
       cmdclass=hpat_build_commands,
-      ext_modules=_ext_mods)
+      ext_modules=_ext_mods,
+      entry_points={
+          "numba_extensions": [
+              "init = hpat:_init_extension",
+          ],
+      },
+)


### PR DESCRIPTION
This PR shows how to create Numba extension for Pandas according the [documentation](http://numba.pydata.org/numba-doc/latest/extending/entrypoints.html).

See test `numba_pandas/tests/test_pandas.py`.

_Implicit_ loading of extension is supported in Numba >= 0.46.
Test file also shows how to load extension _explicitly_ for Numba < 0.46.

For HPAT version not ported to Numba 0.46 it is possible to run the test with Numba 0.46:
comment the line `import hpat.compiler` in `hpat/__init__.py`.

This test is not in CI yet.

`_init_extension()` imports only overloads used in the test. It should be extended for all overloads for Pandas.

I think we should consider moving Pandas overloads to `numba_pandas` package.