### PR TITLE
Add tests with numba.jit for Series

### DIFF
--- a/hpat/tests/test_series.py
+++ b/hpat/tests/test_series.py
@@ -4107,5 +4107,140 @@ class TestSeries(unittest.TestCase):
         self.assertIn(msg, str(raises.exception))
 
 
+# Sort Lines Ascending
+_numba_not_supported_tests = [
+    "test_create_str",
+    "test_create1",
+    "test_create2",
+    "test_getitem_series_str1",
+    "test_getitem_series1",
+    "test_list_convert",
+    "test_np_call_on_series1",
+    "test_pass_df_str",
+    "test_pass_df1",
+    "test_pass_series_str",
+    "test_pass_series1",
+    "test_pass_series2",
+    "test_series_apply1",
+    "test_series_argsort_parallel",
+    "test_series_astype_float_to_int32",
+    "test_series_astype_int_to_float64",
+    "test_series_astype_int_to_str1",
+    "test_series_astype_int_to_str2",
+    "test_series_astype_int32_to_int64",
+    "test_series_astype_str_index_int",
+    "test_series_astype_str_index_str",
+    "test_series_astype_str_to_str_index_int",
+    "test_series_astype_str_to_str_index_str",
+    "test_series_astype_str_to_str1",
+    "test_series_astype_str_to_str2",
+    "test_series_attr7",
+    "test_series_combine_assert1",
+    "test_series_combine_assert2",
+    "test_series_combine_different_types",
+    "test_series_combine_float3264",
+    "test_series_combine_integer_samelen",
+    "test_series_combine_integer",
+    "test_series_combine_samelen",
+    "test_series_combine_value_samelen",
+    "test_series_combine_value",
+    "test_series_combine",
+    "test_series_concat1",
+    "test_series_corr1",
+    "test_series_count1",
+    "test_series_cov1",
+    "test_series_dist_input1",
+    "test_series_dist_input2",
+    "test_series_dropna_bool_no_index1",
+    "test_series_dropna_str_parallel1",
+    "test_series_fillna_bool_no_index1",
+    "test_series_fillna_float_inplace3",
+    "test_series_fillna_inplace_non_literal",
+    "test_series_fillna_str_inplace_empty1",
+    "test_series_fillna_str_inplace1",
+    "test_series_fusion1",
+    "test_series_fusion2",
+    "test_series_head_default1",
+    "test_series_head_index_parallel1",
+    "test_series_head_index1",
+    "test_series_head_index2",
+    "test_series_head_index3",
+    "test_series_head_noidx_float",
+    "test_series_head_parallel1",
+    "test_series_head1",
+    "test_series_iat1",
+    "test_series_iat2",
+    "test_series_iloc1",
+    "test_series_iloc2",
+    "test_series_inplace_binop_array",
+    "test_series_list_str_unbox1",
+    "test_series_map_global1",
+    "test_series_map_tup_map1",
+    "test_series_map_tup1",
+    "test_series_map1",
+    "test_series_median_parallel1",
+    "test_series_nlargest_index",
+    "test_series_nlargest_parallel",
+    "test_series_nlargest_unboxing",
+    "test_series_nlargest",
+    "test_series_nsmallest_index",
+    "test_series_nsmallest_parallel",
+    "test_series_nsmallest_unboxing",
+    "test_series_nsmallest",
+    "test_series_op1",
+    "test_series_op2",
+    "test_series_op3",
+    "test_series_op4",
+    "test_series_op6",
+    "test_series_op7",
+    "test_series_rolling1",
+    "test_series_sort_values_parallel1",
+    "test_series_std",
+    "test_series_str_len1",
+    "test_series_str2str",
+    "test_series_sum2",
+    "test_series_ufunc1",
+    "test_series_values1",
+    "test_series_var",
+    "test_series_var1",
+    "test_setitem_series_bool1",
+    "test_setitem_series_bool2",
+    "test_setitem_series1",
+    "test_setitem_series2",
+    "test_static_getitem_series1",
+    "test_static_setitem_series1",
+]
+
+
+def decorate_methods(decorator, methods):
+    """Decorator for classes. It adds new methods decorated with given decorator.
+    It is useful for skipping tests from a base class.
+
+    Example:
+        class MyTestBase(unittest.TestCase):
+            def test_mytest(self):
+                ...
+
+        @decorate_methods(unittest.skip("my reason"), ["test_mytest"])
+        class MyTest(MyTestBase):
+            pass
+    """
+
+    def decorate(cls):
+        def _func(self): pass
+        for attr in methods:
+            setattr(cls, attr, decorator(_func))
+        return cls
+    return decorate
+
+
+@decorate_methods(unittest.skip("numba not supported"), _numba_not_supported_tests)
+class TestSeriesNumba(TestSeries):
+
+    def jit(self, *args, **kwargs):
+        import numba
+        return numba.njit(*args, **kwargs)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/hpat/tests/test_series.py
+++ b/hpat/tests/test_series.py
@@ -4239,7 +4239,13 @@ class TestSeriesNumba(TestSeries):
 
     def jit(self, *args, **kwargs):
         import numba
-        return numba.njit(*args, **kwargs)
+        import warnings
+        if 'nopython' in kwargs:
+            warnings.warn('nopython is set to True and is ignored', RuntimeWarning)
+        if 'parallel' in kwargs:
+            warnings.warn('parallel is set to True and is ignored', RuntimeWarning)
+        kwargs.update({'nopython': True, 'parallel': True})
+        return numba.jit(*args, **kwargs)
 
 
 if __name__ == "__main__":

--- a/hpat/tests/test_series.py
+++ b/hpat/tests/test_series.py
@@ -153,8 +153,8 @@ GLOBAL_VAL = 2
 
 class TestSeries(unittest.TestCase):
 
-    def jit(self, func):
-        return hpat.jit(func)
+    def jit(self, *args, **kwargs):
+        return hpat.jit(*args, **kwargs)
 
     def test_create1(self):
         def test_impl():

--- a/hpat/tests/test_series.py
+++ b/hpat/tests/test_series.py
@@ -153,11 +153,14 @@ GLOBAL_VAL = 2
 
 class TestSeries(unittest.TestCase):
 
+    def jit(self, func):
+        return hpat.jit(func)
+
     def test_create1(self):
         def test_impl():
             df = pd.DataFrame({'A': [1, 2, 3]})
             return (df.A == 1).sum()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         self.assertEqual(hpat_func(), test_impl())
 
@@ -169,7 +172,7 @@ class TestSeries(unittest.TestCase):
                           ['lmn', 'opq', 'rstuvwxyz']
                           ])
             return S
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         result_ref = test_impl()
         result = hpat_func()
@@ -183,7 +186,7 @@ class TestSeries(unittest.TestCase):
                           [-112233, 445566, 778899]
                           ])
             return S
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         result_ref = test_impl()
         result = hpat_func()
@@ -197,7 +200,7 @@ class TestSeries(unittest.TestCase):
                           [11.2233, 44.5566, -778.899]
                           ])
             return S
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         result_ref = test_impl()
         result = hpat_func()
@@ -207,7 +210,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(n):
             df = pd.DataFrame({'A': np.arange(n)})
             return (df.A == 2).sum()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         self.assertEqual(hpat_func(n), test_impl(n))
@@ -216,7 +219,7 @@ class TestSeries(unittest.TestCase):
         def test_impl():
             A = pd.Series([1, 2, 3])
             return A
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         pd.testing.assert_series_equal(hpat_func(), test_impl())
 
@@ -225,7 +228,7 @@ class TestSeries(unittest.TestCase):
         def test_impl():
             A = pd.Series([1, 2, 3], ['A', 'C', 'B'])
             return A
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         pd.testing.assert_series_equal(hpat_func(), test_impl())
 
@@ -233,7 +236,7 @@ class TestSeries(unittest.TestCase):
         def test_impl():
             A = pd.Series([1, 2, 3], index=['A', 'C', 'B'])
             return A
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         pd.testing.assert_series_equal(hpat_func(), test_impl())
 
@@ -241,7 +244,7 @@ class TestSeries(unittest.TestCase):
         def test_impl():
             A = pd.Series([1, 2, 3], index=['A', 'C', 'B'], name='A')
             return A
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         pd.testing.assert_series_equal(hpat_func(), test_impl())
 
@@ -249,7 +252,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(name):
             A = pd.Series([1, 2, 3], index=['A', 'C', 'B'], name=name)
             return A
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         pd.testing.assert_series_equal(hpat_func('A'), test_impl('A'))
 
@@ -257,14 +260,14 @@ class TestSeries(unittest.TestCase):
         def test_impl():
             df = pd.DataFrame({'A': ['a', 'b', 'c']})
             return (df.A == 'a').sum()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         self.assertEqual(hpat_func(), test_impl())
 
     def test_pass_df1(self):
         def test_impl(df):
             return (df.A == 2).sum()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         df = pd.DataFrame({'A': np.arange(n)})
@@ -273,7 +276,7 @@ class TestSeries(unittest.TestCase):
     def test_pass_df_str(self):
         def test_impl(df):
             return (df.A == 'a').sum()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         df = pd.DataFrame({'A': ['a', 'b', 'c']})
         self.assertEqual(hpat_func(df), test_impl(df))
@@ -282,7 +285,7 @@ class TestSeries(unittest.TestCase):
         # TODO: check to make sure it is series type
         def test_impl(A):
             return (A == 2).sum()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         df = pd.DataFrame({'A': np.arange(n)})
@@ -293,7 +296,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(A):
             df = pd.DataFrame({'A': A})
             return (df.A == 2).sum()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         df = pd.DataFrame({'A': np.arange(n)})
@@ -302,7 +305,7 @@ class TestSeries(unittest.TestCase):
     def test_pass_series_str(self):
         def test_impl(A):
             return (A == 'a').sum()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         df = pd.DataFrame({'A': ['a', 'b', 'c']})
         self.assertEqual(hpat_func(df.A), test_impl(df.A))
@@ -310,7 +313,7 @@ class TestSeries(unittest.TestCase):
     def test_pass_series_index1(self):
         def test_impl(A):
             return A
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([3, 5, 6], ['a', 'b', 'c'], name='A')
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -318,7 +321,7 @@ class TestSeries(unittest.TestCase):
     def test_series_size(self):
         def test_impl(S):
             return S.size
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         for S, expected in [
@@ -335,7 +338,7 @@ class TestSeries(unittest.TestCase):
     def test_series_attr2(self):
         def test_impl(A):
             return A.copy().values
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         df = pd.DataFrame({'A': np.arange(n)})
@@ -344,7 +347,7 @@ class TestSeries(unittest.TestCase):
     def test_series_attr3(self):
         def test_impl(A):
             return A.min()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         df = pd.DataFrame({'A': np.arange(n)})
@@ -353,7 +356,7 @@ class TestSeries(unittest.TestCase):
     def test_series_attr4(self):
         def test_impl(A):
             return A.cumsum().values
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         df = pd.DataFrame({'A': np.arange(n)})
@@ -362,7 +365,7 @@ class TestSeries(unittest.TestCase):
     def test_series_argsort1(self):
         def test_impl(A):
             return A.argsort()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         A = pd.Series(np.random.ranf(n))
@@ -371,7 +374,7 @@ class TestSeries(unittest.TestCase):
     def test_series_argsort2(self):
         def test_impl(S):
             return S.argsort()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([1, -1, 0, 1, np.nan], [1, 2, 3, 4, 5])
         pd.testing.assert_series_equal(test_impl(S), hpat_func(S))
@@ -380,7 +383,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(series, kind):
             return series.argsort(axis=0, kind=kind, order=None)
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         all_data = test_global_input_data_numeric
 
@@ -394,7 +397,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(series, kind):
             return series.argsort(axis=0, kind=kind, order=None)
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         all_data = test_global_input_data_numeric
 
@@ -410,7 +413,7 @@ class TestSeries(unittest.TestCase):
     def test_series_attr6(self):
         def test_impl(A):
             return A.take([2, 3]).values
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         df = pd.DataFrame({'A': np.arange(n)})
@@ -419,7 +422,7 @@ class TestSeries(unittest.TestCase):
     def test_series_attr7(self):
         def test_impl(A):
             return A.astype(np.float64)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         df = pd.DataFrame({'A': np.arange(n)})
@@ -429,7 +432,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies getting Series attribute ndim is supported'''
         def test_impl(S):
             return S.ndim
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         S = pd.Series(np.arange(n))
@@ -439,7 +442,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies getting Series attribute T is supported'''
         def test_impl(S):
             return S.T
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         S = pd.Series(np.arange(n))
@@ -448,7 +451,7 @@ class TestSeries(unittest.TestCase):
     def test_series_copy_str1(self):
         def test_impl(A):
             return A.copy()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series(['aa', 'bb', 'cc'])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -456,7 +459,7 @@ class TestSeries(unittest.TestCase):
     def test_series_copy_int1(self):
         def test_impl(A):
             return A.copy()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([1, 2, 3])
         np.testing.assert_array_equal(hpat_func(S), test_impl(S))
@@ -464,7 +467,7 @@ class TestSeries(unittest.TestCase):
     def test_series_copy_deep(self):
         def test_impl(A, deep):
             return A.copy(deep=deep)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         for S in [
             pd.Series([1, 2]),
@@ -492,7 +495,7 @@ class TestSeries(unittest.TestCase):
         def test_series_corr_impl(S1, S2, min_periods=None):
             return S1.corr(S2, min_periods=min_periods)
 
-        hpat_func = hpat.jit(test_series_corr_impl)
+        hpat_func = self.jit(test_series_corr_impl)
         test_input_data1 = [[.2, .0, .6, .2],
                             [.2, .0, .6, .2, .5, .6, .7, .8],
                             [],
@@ -520,7 +523,7 @@ class TestSeries(unittest.TestCase):
         def test_series_corr_impl(S1, S2, min_periods=None):
             return S1.corr(S2, min_periods=min_periods)
 
-        hpat_func = hpat.jit(test_series_corr_impl)
+        hpat_func = self.jit(test_series_corr_impl)
         S1 = pd.Series([.2, .0, .6, .2])
         S2 = pd.Series(['abcdefgh', 'a', 'abcdefg', 'ab', 'abcdef', 'abc'])
         S3 = pd.Series(['aaaaa', 'bbbb', 'ccc', 'dd', 'e'])
@@ -542,7 +545,7 @@ class TestSeries(unittest.TestCase):
         def test_series_corr_impl(S1, S2, min_periods=None):
             return S1.corr(S2, min_periods)
 
-        hpat_func = hpat.jit(test_series_corr_impl)
+        hpat_func = self.jit(test_series_corr_impl)
         S1 = pd.Series([.2, .0, .6, .2])
         S2 = pd.Series([.3, .6, .0, .1])
 
@@ -562,7 +565,7 @@ class TestSeries(unittest.TestCase):
         '''
         def test_impl(S):
             return S.astype(str)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         S = pd.Series(np.arange(n))
@@ -574,7 +577,7 @@ class TestSeries(unittest.TestCase):
         '''
         def test_impl(S):
             return S.astype('str')
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         S = pd.Series(np.arange(n))
@@ -586,7 +589,7 @@ class TestSeries(unittest.TestCase):
         '''
         def test_impl(S):
             return S.astype(str)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series(['aa', 'bb', 'cc'])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -597,7 +600,7 @@ class TestSeries(unittest.TestCase):
         '''
         def test_impl(S):
             return S.astype('str')
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series(['aa', 'bb', 'cc'])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -610,7 +613,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             return S.astype(str)
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series(['aa', 'bb', 'cc'], index=['d', 'e', 'f'])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -623,7 +626,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             return S.astype(str)
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series(['aa', 'bb', 'cc'], index=[1, 2, 3])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -635,7 +638,7 @@ class TestSeries(unittest.TestCase):
         '''
         def test_impl(A):
             return A.astype(str)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([pd.Timestamp('20130101 09:00:00'),
                        pd.Timestamp('20130101 09:00:02'),
@@ -653,7 +656,7 @@ class TestSeries(unittest.TestCase):
         '''
         def test_impl(A):
             return A.astype(str)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11.0
         S = pd.Series(np.arange(n))
@@ -665,7 +668,7 @@ class TestSeries(unittest.TestCase):
         '''
         def test_impl(A):
             return A.astype(np.int64)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         S = pd.Series(np.arange(n), dtype=np.int32)
@@ -677,7 +680,7 @@ class TestSeries(unittest.TestCase):
         '''
         def test_impl(A):
             return A.astype(np.float64)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         S = pd.Series(np.arange(n))
@@ -689,7 +692,7 @@ class TestSeries(unittest.TestCase):
         '''
         def test_impl(A):
             return A.astype(np.int32)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11.0
         S = pd.Series(np.arange(n))
@@ -702,7 +705,7 @@ class TestSeries(unittest.TestCase):
         '''
         def test_impl(A):
             return A.astype('int32')
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11.0
         S = pd.Series(np.arange(n))
@@ -717,7 +720,7 @@ class TestSeries(unittest.TestCase):
 
         def test_impl(A):
             return A.astype(np.int32)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         S = pd.Series([str(x) for x in np.arange(n) - n // 2])
@@ -730,7 +733,7 @@ class TestSeries(unittest.TestCase):
         '''
         def test_impl(A):
             return A.astype(np.float64)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series(['3.24', '1E+05', '-1', '-1.3E-01', 'nan', 'inf'])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -742,7 +745,7 @@ class TestSeries(unittest.TestCase):
 
         def test_impl(S):
             return S.astype(str)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series(['aa', 'bb', 'cc'], index=['a', 'b', 'c'])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -755,7 +758,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             return S.astype(str)
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series(['aa', 'bb', 'cc'], index=[2, 3, 5])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -763,7 +766,7 @@ class TestSeries(unittest.TestCase):
     def test_np_call_on_series1(self):
         def test_impl(A):
             return np.min(A)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         df = pd.DataFrame({'A': np.arange(n)})
@@ -772,7 +775,7 @@ class TestSeries(unittest.TestCase):
     def test_series_values(self):
         def test_impl(A):
             return A.values
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         df = pd.DataFrame({'A': np.arange(n)})
@@ -781,7 +784,7 @@ class TestSeries(unittest.TestCase):
     def test_series_values1(self):
         def test_impl(A):
             return (A == 2).values
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         df = pd.DataFrame({'A': np.arange(n)})
@@ -790,7 +793,7 @@ class TestSeries(unittest.TestCase):
     def test_series_shape1(self):
         def test_impl(A):
             return A.shape
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         df = pd.DataFrame({'A': np.arange(n)})
@@ -800,7 +803,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(A):
             A[0] = 2
             return (A == 2).sum()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         df = pd.DataFrame({'A': np.arange(n)})
@@ -810,7 +813,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(A, i):
             A[i] = 2
             return (A == 2).sum()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         df = pd.DataFrame({'A': np.arange(n)})
@@ -819,7 +822,7 @@ class TestSeries(unittest.TestCase):
     def test_setitem_series2(self):
         def test_impl(A, i):
             A[i] = 100
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         df = pd.DataFrame({'A': np.arange(n)})
@@ -834,7 +837,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(A, i):
             S = pd.Series(A)
             S[i] = 100
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         A = np.arange(n)
@@ -847,7 +850,7 @@ class TestSeries(unittest.TestCase):
     def test_setitem_series_bool1(self):
         def test_impl(A):
             A[A > 3] = 100
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         df = pd.DataFrame({'A': np.arange(n)})
@@ -860,7 +863,7 @@ class TestSeries(unittest.TestCase):
     def test_setitem_series_bool2(self):
         def test_impl(A, B):
             A[A > 3] = B[A > 3]
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         df = pd.DataFrame({'A': np.arange(n), 'B': np.arange(n)**2})
@@ -873,7 +876,7 @@ class TestSeries(unittest.TestCase):
     def test_static_getitem_series1(self):
         def test_impl(A):
             return A[0]
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         A = pd.Series(np.arange(n))
@@ -882,7 +885,7 @@ class TestSeries(unittest.TestCase):
     def test_getitem_series1(self):
         def test_impl(A, i):
             return A[i]
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         df = pd.DataFrame({'A': np.arange(n)})
@@ -891,7 +894,7 @@ class TestSeries(unittest.TestCase):
     def test_getitem_series_str1(self):
         def test_impl(A, i):
             return A[i]
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         df = pd.DataFrame({'A': ['aa', 'bb', 'cc']})
         self.assertEqual(hpat_func(df.A, 0), test_impl(df.A, 0))
@@ -899,7 +902,7 @@ class TestSeries(unittest.TestCase):
     def test_series_iat1(self):
         def test_impl(A):
             return A.iat[3]
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         S = pd.Series(np.arange(n)**2)
@@ -909,7 +912,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(A):
             A.iat[3] = 1
             return A
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         S = pd.Series(np.arange(n)**2)
@@ -918,7 +921,7 @@ class TestSeries(unittest.TestCase):
     def test_series_iloc1(self):
         def test_impl(A):
             return A.iloc[3]
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         S = pd.Series(np.arange(n)**2)
@@ -927,7 +930,7 @@ class TestSeries(unittest.TestCase):
     def test_series_iloc2(self):
         def test_impl(A):
             return A.iloc[3:8]
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         S = pd.Series(np.arange(n)**2)
@@ -938,7 +941,7 @@ class TestSeries(unittest.TestCase):
         arithmetic_binops = ('+', '-', '*', '/', '//', '%', '**')
         for operator in arithmetic_binops:
             test_impl = _make_func_use_binop1(operator)
-            hpat_func = hpat.jit(test_impl)
+            hpat_func = self.jit(test_impl)
 
             n = 11
             df = pd.DataFrame({'A': np.arange(1, n), 'B': np.ones(n - 1)})
@@ -949,7 +952,7 @@ class TestSeries(unittest.TestCase):
 
         for operator in arithmetic_binops:
             test_impl = _make_func_use_binop1(operator)
-            hpat_func = hpat.jit(test_impl)
+            hpat_func = self.jit(test_impl)
 
             n = 11
             if platform.system() == 'Windows' and not IS_32BITS:
@@ -963,7 +966,7 @@ class TestSeries(unittest.TestCase):
 
         for operator in arithmetic_binops:
             test_impl = _make_func_use_binop2(operator)
-            hpat_func = hpat.jit(test_impl)
+            hpat_func = self.jit(test_impl)
 
             n = 11
             df = pd.DataFrame({'A': np.arange(1, n), 'B': np.ones(n - 1)})
@@ -974,7 +977,7 @@ class TestSeries(unittest.TestCase):
 
         for operator in arithmetic_binops:
             test_impl = _make_func_use_binop2(operator)
-            hpat_func = hpat.jit(test_impl)
+            hpat_func = self.jit(test_impl)
 
             n = 11
             df = pd.DataFrame({'A': np.arange(1, n)})
@@ -985,7 +988,7 @@ class TestSeries(unittest.TestCase):
 
         for method in arithmetic_methods:
             test_impl = _make_func_use_method_arg1(method)
-            hpat_func = hpat.jit(test_impl)
+            hpat_func = self.jit(test_impl)
 
             n = 11
             df = pd.DataFrame({'A': np.arange(1, n), 'B': np.ones(n - 1)})
@@ -999,7 +1002,7 @@ class TestSeries(unittest.TestCase):
 
         for method in arithmetic_methods:
             test_impl = _make_func_use_method_arg1(method)
-            hpat_func = hpat.jit(test_impl)
+            hpat_func = self.jit(test_impl)
 
             n = 11
             if platform.system() == 'Windows' and not IS_32BITS:
@@ -1017,7 +1020,7 @@ class TestSeries(unittest.TestCase):
 
         for method in arithmetic_methods:
             test_impl = _make_func_use_method_arg1(method)
-            hpat_func = hpat.jit(test_impl)
+            hpat_func = self.jit(test_impl)
 
             n = 11
             operand_series = pd.Series(np.arange(1, n))
@@ -1030,7 +1033,7 @@ class TestSeries(unittest.TestCase):
     def test_series_op6(self):
         def test_impl(A):
             return -A
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         A = pd.Series(np.arange(n))
@@ -1041,7 +1044,7 @@ class TestSeries(unittest.TestCase):
 
         for operator in comparison_binops:
             test_impl = _make_func_use_binop1(operator)
-            hpat_func = hpat.jit(test_impl)
+            hpat_func = self.jit(test_impl)
 
             n = 11
             A = pd.Series(np.arange(n))
@@ -1053,7 +1056,7 @@ class TestSeries(unittest.TestCase):
 
         for method in comparison_methods:
             test_impl = _make_func_use_method_arg1(method)
-            hpat_func = hpat.jit(test_impl)
+            hpat_func = self.jit(test_impl)
 
             n = 11
             A = pd.Series(np.arange(n))
@@ -1066,7 +1069,7 @@ class TestSeries(unittest.TestCase):
 
         for method in comparison_methods:
             test_impl = _make_func_use_method_arg1(method)
-            hpat_func = hpat.jit(test_impl)
+            hpat_func = self.jit(test_impl)
 
             n = 11
             operand_series = pd.Series(np.arange(1, n))
@@ -1081,7 +1084,7 @@ class TestSeries(unittest.TestCase):
 
         for method in comparison_methods:
             test_impl = _make_func_use_method_arg1(method)
-            hpat_func = hpat.jit(test_impl)
+            hpat_func = self.jit(test_impl)
 
             n = 11
             operand_series = pd.Series(np.arange(1, n))
@@ -1095,7 +1098,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(A, B):
             A += B
             return A
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         A = np.arange(n)**2.0  # TODO: use 2 for test int casting
@@ -1105,7 +1108,7 @@ class TestSeries(unittest.TestCase):
     def test_series_fusion1(self):
         def test_impl(A, B):
             return A + B + 1
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         if platform.system() == 'Windows' and not IS_32BITS:
@@ -1124,7 +1127,7 @@ class TestSeries(unittest.TestCase):
             if A[0] == 0:
                 S = A + 1
             return S + B
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         if platform.system() == 'Windows' and not IS_32BITS:
@@ -1139,7 +1142,7 @@ class TestSeries(unittest.TestCase):
     def test_series_len(self):
         def test_impl(A, i):
             return len(A)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         df = pd.DataFrame({'A': np.arange(n)})
@@ -1149,7 +1152,7 @@ class TestSeries(unittest.TestCase):
         def test_impl():
             A = pd.Series([1, 2, 3])
             return A
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         pd.testing.assert_series_equal(hpat_func(), test_impl())
 
@@ -1157,14 +1160,14 @@ class TestSeries(unittest.TestCase):
         def test_impl():
             A = pd.Series(['1', '2', '3'])
             return A
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         pd.testing.assert_series_equal(hpat_func(), test_impl())
 
     def test_series_list_str_unbox1(self):
         def test_impl(A):
             return A.iloc[0]
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([['aa', 'b'], ['ccc'], []])
         np.testing.assert_array_equal(hpat_func(S), test_impl(S))
@@ -1177,14 +1180,14 @@ class TestSeries(unittest.TestCase):
         # type can't provide calltype
         def test_impl(i):
             return np.int32(i)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         self.assertEqual(hpat_func(1), test_impl(1))
 
     def test_series_ufunc1(self):
         def test_impl(A, i):
             return np.isinf(A).values
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         df = pd.DataFrame({'A': np.arange(n)})
@@ -1196,7 +1199,7 @@ class TestSeries(unittest.TestCase):
                                'two': ['foo', 'bar', 'baz'],
                                'three': [True, False, True]})
             return df.one.values, df.two.values, df.three.values
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         one, two, three = hpat_func()
         self.assertTrue(isinstance(one, np.ndarray))
@@ -1207,7 +1210,7 @@ class TestSeries(unittest.TestCase):
     def test_series_empty_like(self):
         def test_impl(A):
             return np.empty_like(A)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         n = 11
         df = pd.DataFrame({'A': np.arange(n)})
         self.assertTrue(isinstance(hpat_func(df.A), np.ndarray))
@@ -1218,7 +1221,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.fillna() implementation handles 'index' as axis argument'''
         def test_impl(S):
             return S.fillna(5.0, axis='index')
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([1.0, 2.0, np.nan, 1.0, np.inf])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -1229,7 +1232,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.fillna() implementation handles 0 as axis argument'''
         def test_impl(S):
             return S.fillna(5.0, axis=0)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([1.0, 2.0, np.nan, 1.0, np.inf])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -1240,7 +1243,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.fillna() implementation handles correct non-literal axis argument'''
         def test_impl(S, axis):
             return S.fillna(5.0, axis=axis)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([1.0, 2.0, np.nan, 1.0, np.inf])
         for axis in [0, 'index']:
@@ -1252,7 +1255,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.fillna() applied to a named float Series obtained from a DataFrame'''
         def test_impl(S):
             return S.fillna(5.0)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         # TODO: check_names must be fixed
         df = pd.DataFrame({'A': [1.0, 2.0, np.nan, 1.0, np.inf]})
@@ -1264,7 +1267,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.fillna() implementation for float series with default index'''
         def test_impl(S):
             return S.fillna(5.0)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         for data in test_global_input_data_float64:
             S = pd.Series(data)
@@ -1276,7 +1279,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.fillna() implementation for float series with string index'''
         def test_impl(S):
             return S.fillna(5.0)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([1.0, 2.0, np.nan, 1.0, np.inf], ['a', 'b', 'c', 'd', 'e'])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -1286,7 +1289,7 @@ class TestSeries(unittest.TestCase):
     def test_series_fillna_float_index3(self):
         def test_impl(S):
             return S.fillna(5.0)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([1.0, 2.0, np.nan, 1.0, np.inf], index=[1, 2, 5, 7, 10])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -1297,7 +1300,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.fillna() applied to a named float Series obtained from a DataFrame'''
         def test_impl(S):
             return S.fillna("dd")
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         # TODO: check_names must be fixed
         df = pd.DataFrame({'A': ['aa', 'b', None, 'cccd', '']})
@@ -1310,7 +1313,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.fillna() implementation for series of strings with default index'''
         def test_impl(S):
             return S.fillna("dd")
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series(['aa', 'b', None, 'cccd', ''])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -1321,7 +1324,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.fillna() implementation for series of strings with string index'''
         def test_impl(S):
             return S.fillna("dd")
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series(['aa', 'b', None, 'cccd', ''], ['a', 'b', 'c', 'd', 'e'])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -1332,7 +1335,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             return S.fillna("dd")
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series(['aa', 'b', None, 'cccd', ''], index=[1, 2, 5, 7, 10])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -1344,7 +1347,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             S.fillna(5.0, inplace=True)
             return S
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([1.0, 2.0, np.nan, 1.0, np.inf])
         S2 = S1.copy()
@@ -1355,7 +1358,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.fillna(inplace=True) results are reflected back in the original float series'''
         def test_impl(S):
             return S.fillna(inplace=True)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([1.0, 2.0, np.nan, 1.0, np.inf])
         S2 = S1.copy()
@@ -1367,7 +1370,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.fillna() implementation correcly handles omitted inplace argument as default False'''
         def test_impl(S):
             return S.fillna(5.0)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([1.0, 2.0, np.nan, 1.0, np.inf])
         S2 = S1.copy()
@@ -1379,7 +1382,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S, param):
             S.fillna(5.0, inplace=param)
             return S
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([1.0, 2.0, np.nan, 1.0, np.inf])
         expected = ValueError if hpat.config.config_pipeline_hpat_default else TypingError
@@ -1394,7 +1397,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             S.fillna("dd", inplace=True)
             return S
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series(['aa', 'b', None, 'cccd', ''])
         S2 = S1.copy()
@@ -1406,7 +1409,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.fillna(inplace=True) results are reflected back in the original string series'''
         def test_impl(S):
             return S.fillna("dd", inplace=True)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series(['aa', 'b', None, 'cccd', ''])
         S2 = S1.copy()
@@ -1420,7 +1423,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(A):
             A.fillna("", inplace=True)
             return A
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series(['aa', 'b', None, 'cccd', ''])
         S2 = S1.copy()
@@ -1434,7 +1437,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.fillna() implementation for datetime series and np.datetime64 value'''
         def test_impl(S, value):
             return S.fillna(value)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         value = np.datetime64('2020-05-03', 'ns')
         S = pd.Series([pd.NaT, pd.Timestamp('1970-12-01'), pd.Timestamp('2012-07-25'), None])
@@ -1446,7 +1449,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             value = pd.Timestamp('2020-05-03')
             return S.fillna(value)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([pd.NaT, pd.Timestamp('1970-12-01'), pd.Timestamp('2012-07-25')])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -1455,7 +1458,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.fillna() implementation for bool series with default index'''
         def test_impl(S):
             return S.fillna(True)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([True, False, False, True])
         S2 = S1.copy()
@@ -1467,7 +1470,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.fillna() implementation for integer series with default index'''
         def test_impl(S):
             return S.fillna(7)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         S1 = pd.Series(np.arange(n, dtype=np.int64))
@@ -1480,7 +1483,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.dropna() implementation handles 'index' as axis argument'''
         def test_impl(S):
             return S.dropna(axis='index')
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([1.0, 2.0, np.nan, 1.0, np.inf])
         S2 = S1.copy()
@@ -1492,7 +1495,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.dropna() implementation handles 0 as axis argument'''
         def test_impl(S):
             return S.dropna(axis=0)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([1.0, 2.0, np.nan, 1.0, np.inf])
         S2 = S1.copy()
@@ -1504,7 +1507,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.dropna() implementation handles correct non-literal axis argument'''
         def test_impl(S, axis):
             return S.dropna(axis=axis)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([1.0, 2.0, np.nan, 1.0, np.inf])
         S2 = S1.copy()
@@ -1517,7 +1520,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.dropna() implementation for float series with default index'''
         def test_impl(S):
             return S.dropna()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         for data in test_global_input_data_float64:
             S1 = pd.Series(data)
@@ -1530,7 +1533,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.dropna() implementation for float series with string index'''
         def test_impl(S):
             return S.dropna()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([1.0, 2.0, np.nan, 1.0, np.inf], ['a', 'b', 'c', 'd', 'e'])
         S2 = S1.copy()
@@ -1542,7 +1545,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.dropna() implementation for series of strings with default index'''
         def test_impl(S):
             return S.dropna()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series(['aa', 'b', None, 'cccd', ''])
         S2 = S1.copy()
@@ -1554,7 +1557,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.dropna() implementation for series of strings with string index'''
         def test_impl(S):
             return S.dropna()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series(['aa', 'b', None, 'cccd', ''], ['a', 'b', 'c', 'd', 'e'])
         S2 = S1.copy()
@@ -1566,7 +1569,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             return S.dropna()
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series(['aa', 'b', None, 'cccd', ''], index=[1, 2, 5, 7, 10])
         S2 = S1.copy()
@@ -1578,7 +1581,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             S.dropna(inplace=True)
             return S
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([1.0, 2.0, np.nan, 1.0, np.inf])
         S2 = S1.copy()
@@ -1589,7 +1592,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.dropna(inplace=True) results are reflected back in the original float series'''
         def test_impl(S):
             return S.dropna(inplace=True)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([1.0, 2.0, np.nan, 1.0, np.inf])
         S2 = S1.copy()
@@ -1605,7 +1608,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             S.dropna(inplace=True)
             return S
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series(['aa', 'b', None, 'cccd', ''])
         S2 = S1.copy()
@@ -1616,7 +1619,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.dropna(inplace=True) results are reflected back in the original string series'''
         def test_impl(S):
             return S.dropna(inplace=True)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series(['aa', 'b', None, 'cccd', ''])
         S2 = S1.copy()
@@ -1629,7 +1632,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(A):
             B = A.dropna()
             return (B == 'gg').sum()
-        hpat_func = hpat.jit(distributed=['A'])(test_impl)
+        hpat_func = self.jit(distributed=['A'])(test_impl)
 
         S1 = pd.Series(['aa', 'b', None, 'ccc', 'dd', 'gg'])
         start, end = get_start_end(len(S1))
@@ -1647,7 +1650,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.dropna() implementation for datetime series with default index'''
         def test_impl(S):
             return S.dropna()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([pd.NaT, pd.Timestamp('1970-12-01'), pd.Timestamp('2012-07-25')])
         S2 = S1.copy()
@@ -1657,7 +1660,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.dropna() implementation for bool series with default index'''
         def test_impl(S):
             return S.dropna()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([True, False, False, True])
         S2 = S1.copy()
@@ -1669,7 +1672,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies Series.dropna() implementation for integer series with default index'''
         def test_impl(S):
             return S.dropna()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         S1 = pd.Series(np.arange(n, dtype=np.int64))
@@ -1684,7 +1687,7 @@ class TestSeries(unittest.TestCase):
     def test_series_rename1(self):
         def test_impl(A):
             return A.rename('B')
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         df = pd.DataFrame({'A': [1.0, 2.0, np.nan, 1.0]})
         pd.testing.assert_series_equal(hpat_func(df.A), test_impl(df.A))
@@ -1692,7 +1695,7 @@ class TestSeries(unittest.TestCase):
     def test_series_sum_default(self):
         def test_impl(S):
             return S.sum()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([1., 2., 3.])
         self.assertEqual(hpat_func(S), test_impl(S))
@@ -1700,7 +1703,7 @@ class TestSeries(unittest.TestCase):
     def test_series_sum_nan(self):
         def test_impl(S):
             return S.sum()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         # column with NA
         S = pd.Series([np.nan, 2., 3.])
@@ -1714,7 +1717,7 @@ class TestSeries(unittest.TestCase):
     def test_series_sum_skipna_false(self):
         def test_impl(S):
             return S.sum(skipna=False)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([np.nan, 2., 3.])
         self.assertEqual(np.isnan(hpat_func(S)), np.isnan(test_impl(S)))
@@ -1724,7 +1727,7 @@ class TestSeries(unittest.TestCase):
     def test_series_sum2(self):
         def test_impl(S):
             return (S + S).sum()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([np.nan, 2., 3.])
         self.assertEqual(hpat_func(S), test_impl(S))
@@ -1735,7 +1738,7 @@ class TestSeries(unittest.TestCase):
     def test_series_prod(self):
         def test_impl(S, skipna):
             return S.prod(skipna=skipna)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         data_samples = [
             [6, 6, 2, 1, 3, 3, 2, 1, 2],
@@ -1764,7 +1767,7 @@ class TestSeries(unittest.TestCase):
     def test_series_prod_skipna_default(self):
         def test_impl(S):
             return S.prod()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([np.nan, 2, 3.])
         self.assertEqual(hpat_func(S), test_impl(S))
@@ -1772,7 +1775,7 @@ class TestSeries(unittest.TestCase):
     def test_series_count1(self):
         def test_impl(S):
             return S.count()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([np.nan, 2., 3.])
         self.assertEqual(hpat_func(S), test_impl(S))
@@ -1786,7 +1789,7 @@ class TestSeries(unittest.TestCase):
     def test_series_mean(self):
         def test_impl(S):
             return S.mean()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         data_samples = [
             [6, 6, 2, 1, 3, 3, 2, 1, 2],
@@ -1813,7 +1816,7 @@ class TestSeries(unittest.TestCase):
     def test_series_mean_skipna(self):
         def test_impl(S, skipna):
             return S.mean(skipna=skipna)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         data_samples = [
             [6, 6, 2, 1, 3, 3, 2, 1, 2],
@@ -1839,7 +1842,7 @@ class TestSeries(unittest.TestCase):
     def test_series_var1(self):
         def test_impl(S):
             return S.var()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([np.nan, 2., 3.])
         self.assertEqual(hpat_func(S), test_impl(S))
@@ -1847,7 +1850,7 @@ class TestSeries(unittest.TestCase):
     def test_series_min(self):
         def test_impl(S):
             return S.min()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         # TODO type_min/type_max
         for input_data in [[np.nan, 2., np.nan, 3., np.inf, 1, -1000],
@@ -1864,7 +1867,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S, param_skipna):
             return S.min(skipna=param_skipna)
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         for input_data, param_skipna in [([np.nan, 2., np.nan, 3., 1, -1000, np.inf], True),
                                          ([2., 3., 1, np.inf, -1000], False)]:
@@ -1877,7 +1880,7 @@ class TestSeries(unittest.TestCase):
     def test_series_max(self):
         def test_impl(S):
             return S.max()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         # TODO type_min/type_max
         for input_data in [[np.nan, 2., np.nan, 3., np.inf, 1, -1000],
@@ -1894,7 +1897,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S, param_skipna):
             return S.max(skipna=param_skipna)
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         for input_data, param_skipna in [([np.nan, 2., np.nan, 3., 1, -1000, np.inf], True),
                                          ([2., 3., 1, np.inf, -1000], False)]:
@@ -1911,7 +1914,7 @@ class TestSeries(unittest.TestCase):
         input_data = [test_global_input_data_integer64, test_global_input_data_float64]
         extras = [[1, 2, 3, 1, 1, 3], [0.1, 0., 0.1, 0.1]]
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         for data, extra in zip(input_data, extras):
             for d in data:
@@ -1924,7 +1927,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S, asceding):
             return S.value_counts(sort=True, ascending=asceding)
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         data = [1, 0, 0, 1, 1, -1, 0, -1, 0]
 
@@ -1941,7 +1944,7 @@ class TestSeries(unittest.TestCase):
                         [1, 2, 3, np.nan, 1, 3, np.nan, np.inf],
                         [0.1, 3., np.nan, 3., 0.1, 3., np.nan, np.inf, 0.1, 0.1]]
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         for data in data_to_test:
             S = pd.Series(data)
@@ -1954,7 +1957,7 @@ class TestSeries(unittest.TestCase):
         data_to_test = [['a', 'b', 'a', 'b', 'c', 'a'],
                         ['dog', 'cat', 'cat', 'cat', 'dog']]
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         for data in data_to_test:
             for ascending in (True, False):
@@ -1965,7 +1968,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             return S.value_counts()
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         for data in test_global_input_data_integer64:
             index = np.arange(start=1, stop=len(data) + 1)
@@ -1977,14 +1980,14 @@ class TestSeries(unittest.TestCase):
             S = pd.Series([1, 2, 3, 1, 1, 3])
             return S.value_counts()
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         pd.testing.assert_series_equal(hpat_func(), test_impl())
 
     def test_series_dist_input1(self):
         '''Verify distribution of a Series without index'''
         def test_impl(S):
             return S.max()
-        hpat_func = hpat.jit(distributed={'S'})(test_impl)
+        hpat_func = self.jit(distributed={'S'})(test_impl)
 
         n = 111
         S = pd.Series(np.arange(n))
@@ -1997,7 +2000,7 @@ class TestSeries(unittest.TestCase):
         '''Verify distribution of a Series with integer index'''
         def test_impl(S):
             return S.max()
-        hpat_func = hpat.jit(distributed={'S'})(test_impl)
+        hpat_func = self.jit(distributed={'S'})(test_impl)
 
         n = 111
         S = pd.Series(np.arange(n), 1 + np.arange(n))
@@ -2011,7 +2014,7 @@ class TestSeries(unittest.TestCase):
         '''Verify distribution of a Series with string index'''
         def test_impl(S):
             return S.max()
-        hpat_func = hpat.jit(distributed={'S'})(test_impl)
+        hpat_func = self.jit(distributed={'S'})(test_impl)
 
         n = 111
         S = pd.Series(np.arange(n), ['abc{}'.format(id) for id in range(n)])
@@ -2023,7 +2026,7 @@ class TestSeries(unittest.TestCase):
     def test_series_tuple_input1(self):
         def test_impl(s_tup):
             return s_tup[0].max()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 111
         S = pd.Series(np.arange(n))
@@ -2035,7 +2038,7 @@ class TestSeries(unittest.TestCase):
     def test_series_tuple_input_dist1(self):
         def test_impl(s_tup):
             return s_tup[0].max()
-        hpat_func = hpat.jit(locals={'s_tup:input': 'distributed'})(test_impl)
+        hpat_func = self.jit(locals={'s_tup:input': 'distributed'})(test_impl)
 
         n = 111
         S = pd.Series(np.arange(n))
@@ -2048,7 +2051,7 @@ class TestSeries(unittest.TestCase):
     def test_series_rolling1(self):
         def test_impl(S):
             return S.rolling(3).sum()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([1.0, 2., 3., 4., 5.])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -2056,7 +2059,7 @@ class TestSeries(unittest.TestCase):
     def test_series_concat1(self):
         def test_impl(S1, S2):
             return pd.concat([S1, S2]).values
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([1.0, 2., 3., 4., 5.])
         S2 = pd.Series([6., 7.])
@@ -2065,7 +2068,7 @@ class TestSeries(unittest.TestCase):
     def test_series_map1(self):
         def test_impl(S):
             return S.map(lambda a: 2 * a)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([1.0, 2., 3., 4., 5.])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -2073,7 +2076,7 @@ class TestSeries(unittest.TestCase):
     def test_series_map_global1(self):
         def test_impl(S):
             return S.map(lambda a: a + GLOBAL_VAL)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([1.0, 2., 3., 4., 5.])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -2081,7 +2084,7 @@ class TestSeries(unittest.TestCase):
     def test_series_map_tup1(self):
         def test_impl(S):
             return S.map(lambda a: (a, 2 * a))
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([1.0, 2., 3., 4., 5.])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -2090,7 +2093,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             A = S.map(lambda a: (a, 2 * a))
             return A.map(lambda a: a[1])
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([1.0, 2., 3., 4., 5.])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -2098,7 +2101,7 @@ class TestSeries(unittest.TestCase):
     def test_series_combine(self):
         def test_impl(S1, S2):
             return S1.combine(S2, lambda a, b: 2 * a + b)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([1.0, 2., 3., 4., 5.])
         S2 = pd.Series([6.0, 21., 3.6, 5.])
@@ -2107,7 +2110,7 @@ class TestSeries(unittest.TestCase):
     def test_series_combine_float3264(self):
         def test_impl(S1, S2):
             return S1.combine(S2, lambda a, b: 2 * a + b)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([np.float64(1), np.float64(2),
                         np.float64(3), np.float64(4), np.float64(5)])
@@ -2118,7 +2121,7 @@ class TestSeries(unittest.TestCase):
     def test_series_combine_assert1(self):
         def test_impl(S1, S2):
             return S1.combine(S2, lambda a, b: 2 * a + b)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([1, 2, 3])
         S2 = pd.Series([6., 21., 3., 5.])
@@ -2128,7 +2131,7 @@ class TestSeries(unittest.TestCase):
     def test_series_combine_assert2(self):
         def test_impl(S1, S2):
             return S1.combine(S2, lambda a, b: 2 * a + b)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([6., 21., 3., 5.])
         S2 = pd.Series([1, 2, 3])
@@ -2138,7 +2141,7 @@ class TestSeries(unittest.TestCase):
     def test_series_combine_integer(self):
         def test_impl(S1, S2):
             return S1.combine(S2, lambda a, b: 2 * a + b, 16)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([1, 2, 3, 4, 5])
         S2 = pd.Series([6, 21, 3, 5])
@@ -2147,7 +2150,7 @@ class TestSeries(unittest.TestCase):
     def test_series_combine_different_types(self):
         def test_impl(S1, S2):
             return S1.combine(S2, lambda a, b: 2 * a + b)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([6.1, 21.2, 3.3, 5.4, 6.7])
         S2 = pd.Series([1, 2, 3, 4, 5])
@@ -2156,7 +2159,7 @@ class TestSeries(unittest.TestCase):
     def test_series_combine_integer_samelen(self):
         def test_impl(S1, S2):
             return S1.combine(S2, lambda a, b: 2 * a + b)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([1, 2, 3, 4, 5])
         S2 = pd.Series([6, 21, 17, -5, 4])
@@ -2165,7 +2168,7 @@ class TestSeries(unittest.TestCase):
     def test_series_combine_samelen(self):
         def test_impl(S1, S2):
             return S1.combine(S2, lambda a, b: 2 * a + b)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([1.0, 2., 3., 4., 5.])
         S2 = pd.Series([6.0, 21., 3.6, 5., 0.0])
@@ -2174,7 +2177,7 @@ class TestSeries(unittest.TestCase):
     def test_series_combine_value(self):
         def test_impl(S1, S2):
             return S1.combine(S2, lambda a, b: 2 * a + b, 1237.56)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([1.0, 2., 3., 4., 5.])
         S2 = pd.Series([6.0, 21., 3.6, 5.])
@@ -2183,7 +2186,7 @@ class TestSeries(unittest.TestCase):
     def test_series_combine_value_samelen(self):
         def test_impl(S1, S2):
             return S1.combine(S2, lambda a, b: 2 * a + b, 1237.56)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([1.0, 2., 3., 4., 5.])
         S2 = pd.Series([6.0, 21., 3.6, 5., 0.0])
@@ -2192,7 +2195,7 @@ class TestSeries(unittest.TestCase):
     def test_series_apply1(self):
         def test_impl(S):
             return S.apply(lambda a: 2 * a)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([1.0, 2., 3., 4., 5.])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -2200,7 +2203,7 @@ class TestSeries(unittest.TestCase):
     def test_series_abs1(self):
         def test_impl(S):
             return S.abs()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([np.nan, -2., 3., 0.5E-01, 0xFF, 0o7, 0b101])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -2208,7 +2211,7 @@ class TestSeries(unittest.TestCase):
     def test_series_cov1(self):
         def test_impl(S1, S2):
             return S1.cov(S2)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         for pair in _cov_corr_series:
             S1, S2 = pair
@@ -2219,7 +2222,7 @@ class TestSeries(unittest.TestCase):
     def test_series_corr1(self):
         def test_impl(S1, S2):
             return S1.corr(S2)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         for pair in _cov_corr_series:
             S1, S2 = pair
@@ -2230,7 +2233,7 @@ class TestSeries(unittest.TestCase):
     def test_series_str_len1(self):
         def test_impl(S):
             return S.str.len()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series(['aa', 'abc', 'c', 'cccd'])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -2242,7 +2245,7 @@ class TestSeries(unittest.TestCase):
             func_text = "def test_impl(S):\n"
             func_text += "  return S.str.{}()\n".format(method)
             test_impl = _make_func_from_text(func_text)
-            hpat_func = hpat.jit(test_impl)
+            hpat_func = self.jit(test_impl)
 
             S = pd.Series([' \tbbCD\t ', 'ABC', ' mCDm\t', 'abc'])
             pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -2253,7 +2256,7 @@ class TestSeries(unittest.TestCase):
         '''Verify Series.append() concatenates Series with other single Series ignoring indexes'''
         def test_impl(S, other):
             return S.append(other, ignore_index=True)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         dtype_to_data = {'float': [[-2., 3., 9.1, np.nan], [-2., 5.0, np.inf, 0, -1]],
                          'string': [['a', None, 'bbbb', ''], ['dd', None, '', 'e', 'ttt']]}
@@ -2269,7 +2272,7 @@ class TestSeries(unittest.TestCase):
         '''Verify Series.append() concatenates Series with list of other Series ignoring indexes'''
         def test_impl(S1, S2, S3):
             return S1.append([S2, S3], ignore_index=True)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         dtype_to_data = {'float': [[-2., 3., 9.1], [-2., 5.0], [1.0]]}
         if not hpat.config.config_pipeline_hpat_default:
@@ -2285,7 +2288,7 @@ class TestSeries(unittest.TestCase):
         '''Verify Series.append() concatenates Series with tuple of other Series ignoring indexes'''
         def test_impl(S1, S2, S3):
             return S1.append((S2, S3, ), ignore_index=True)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         dtype_to_data = {'float': [[-2., 3., 9.1], [-2., 5.0], [1.0]]}
         if not hpat.config.config_pipeline_hpat_default:
@@ -2302,7 +2305,7 @@ class TestSeries(unittest.TestCase):
         '''Verify Series.append() concatenates Series with other single Series respecting default indexes'''
         def test_impl(S, other):
             return S.append(other)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         dtype_to_data = {'float': [[-2., 3., 9.1], [-2., 5.0]]}
         if not hpat.config.config_pipeline_hpat_default:
@@ -2319,7 +2322,7 @@ class TestSeries(unittest.TestCase):
         '''Verify Series.append() concatenates Series with list of other Series respecting default indexes'''
         def test_impl(S1, S2, S3):
             return S1.append([S2, S3])
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         dtype_to_data = {'float': [[-2., 3., 9.1], [-2., 5.0], [1.0]]}
         if not hpat.config.config_pipeline_hpat_default:
@@ -2335,7 +2338,7 @@ class TestSeries(unittest.TestCase):
         '''Verify Series.append() concatenates Series with tuple of other Series respecting default indexes'''
         def test_impl(S1, S2, S3):
             return S1.append((S2, S3, ))
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         dtype_to_data = {'float': [[-2., 3., 9.1], [-2., 5.0], [1.0]]}
         if not hpat.config.config_pipeline_hpat_default:
@@ -2352,7 +2355,7 @@ class TestSeries(unittest.TestCase):
         '''Verify Series.append() concatenates Series with other single Series respecting integer indexes'''
         def test_impl(S, other):
             return S.append(other)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         dtype_to_data = {'float': [[-2., 3., 9.1, np.nan], [-2., 5.0, np.inf, 0, -1]]}
         if not hpat.config.config_pipeline_hpat_default:
@@ -2370,7 +2373,7 @@ class TestSeries(unittest.TestCase):
         '''Verify Series.append() concatenates Series with list of other Series respecting integer indexes'''
         def test_impl(S1, S2, S3):
             return S1.append([S2, S3])
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         dtype_to_data = {'float': [[-2., 3., 9.1, np.nan], [-2., 5.0, np.inf, 0], [-1.0]]}
         if not hpat.config.config_pipeline_hpat_default:
@@ -2387,7 +2390,7 @@ class TestSeries(unittest.TestCase):
         '''Verify Series.append() concatenates Series with tuple of other Series respecting integer indexes'''
         def test_impl(S1, S2, S3):
             return S1.append((S2, S3, ))
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         dtype_to_data = {'float': [[-2., 3., 9.1, np.nan], [-2., 5.0, np.inf, 0], [-1.0]]}
         if not hpat.config.config_pipeline_hpat_default:
@@ -2405,7 +2408,7 @@ class TestSeries(unittest.TestCase):
         '''Verify Series.append() concatenates Series with other single Series respecting string indexes'''
         def test_impl(S, other):
             return S.append(other)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         dtype_to_data = {'float': [[-2., 3., 9.1, np.nan], [-2., 5.0, np.inf, 0, -1.0]]}
         if not hpat.config.config_pipeline_hpat_default:
@@ -2423,7 +2426,7 @@ class TestSeries(unittest.TestCase):
         '''Verify Series.append() concatenates Series with list of other Series respecting string indexes'''
         def test_impl(S1, S2, S3):
             return S1.append([S2, S3])
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         dtype_to_data = {'float': [[-2., 3., 9.1, np.nan], [-2., 5.0, np.inf, 0], [-1.0]]}
         if not hpat.config.config_pipeline_hpat_default:
@@ -2440,7 +2443,7 @@ class TestSeries(unittest.TestCase):
         '''Verify Series.append() concatenates Series with tuple of other Series respecting string indexes'''
         def test_impl(S1, S2, S3):
             return S1.append((S2, S3, ))
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         dtype_to_data = {'float': [[-2., 3., 9.1, np.nan], [-2., 5.0, np.inf, 0], [-1.0]]}
         if not hpat.config.config_pipeline_hpat_default:
@@ -2458,7 +2461,7 @@ class TestSeries(unittest.TestCase):
         '''Verify Series.append() implementation handles ignore_index argument as Boolean literal'''
         def test_impl(S, other):
             return S.append(other, ignore_index=False)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([-2., 3., 9.1], ['a1', 'b1', 'c1'])
         S2 = pd.Series([-2., 5.0], ['a2', 'b2'])
@@ -2470,7 +2473,7 @@ class TestSeries(unittest.TestCase):
         '''Verify Series.append() implementation raises if ignore_index argument is not a Boolean literal'''
         def test_impl(S, other, param):
             return S.append(other, ignore_index=param)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         ignore_index = True
         S1 = pd.Series([-2., 3., 9.1], ['a1', 'b1', 'c1'])
@@ -2486,7 +2489,7 @@ class TestSeries(unittest.TestCase):
         '''Verify Series.append() implementation handles appending single Series with different dtypes'''
         def test_impl(S, other):
             return S.append(other)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([-2., 3., 9.1], ['a1', 'b1', 'c1'])
         S2 = pd.Series([-2, 5], ['a2', 'b2'])
@@ -2498,7 +2501,7 @@ class TestSeries(unittest.TestCase):
         '''Verify Series.append() implementation handles appending list of Series with different dtypes'''
         def test_impl(S1, S2, S3):
             return S1.append([S2, S3])
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S1 = pd.Series([-2, 3, 9])
         S2 = pd.Series([-2., 5.0])
@@ -2509,7 +2512,7 @@ class TestSeries(unittest.TestCase):
     def test_series_isin_list1(self):
         def test_impl(S, values):
             return S.isin(values)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         S = pd.Series(np.arange(n))
@@ -2519,7 +2522,7 @@ class TestSeries(unittest.TestCase):
     def test_series_isin_list2(self):
         def test_impl(S, values):
             return S.isin(values)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11.0
         S = pd.Series(np.arange(n))
@@ -2529,7 +2532,7 @@ class TestSeries(unittest.TestCase):
     def test_series_isin_list3(self):
         def test_impl(S, values):
             return S.isin(values)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series(['a', 'b', 'q', 'w', 'c', 'd', 'e', 'r'])
         values = ['a', 'q', 'c', 'd', 'e']
@@ -2538,7 +2541,7 @@ class TestSeries(unittest.TestCase):
     def test_series_isin_set1(self):
         def test_impl(S, values):
             return S.isin(values)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         S = pd.Series(np.arange(n))
@@ -2548,7 +2551,7 @@ class TestSeries(unittest.TestCase):
     def test_series_isin_set2(self):
         def test_impl(S, values):
             return S.isin(values)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11.0
         S = pd.Series(np.arange(n))
@@ -2559,7 +2562,7 @@ class TestSeries(unittest.TestCase):
     def test_series_isin_set3(self):
         def test_impl(S, values):
             return S.isin(values)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series(['a', 'b', 'c', 'd', 'e'] * 2)
         values = {'b', 'c', 'e'}
@@ -2568,7 +2571,7 @@ class TestSeries(unittest.TestCase):
     def test_series_isna1(self):
         def test_impl(S):
             return S.isna()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         # column with NA
         S = pd.Series([np.nan, 2., 3., np.inf])
@@ -2577,7 +2580,7 @@ class TestSeries(unittest.TestCase):
     def test_series_isnull1(self):
         def test_impl(S):
             return S.isnull()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         # column with NA
         S = pd.Series([np.nan, 2., 3.])
@@ -2587,7 +2590,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(series):
             return series.isnull()
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         for data in test_global_input_data_numeric + [test_global_input_data_unicode_kind4]:
             series = pd.Series(data * 3)
@@ -2598,7 +2601,7 @@ class TestSeries(unittest.TestCase):
     def test_series_notna1(self):
         def test_impl(S):
             return S.notna()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         # column with NA
         S = pd.Series([np.nan, 2., 3.])
@@ -2608,7 +2611,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             return S.notna()
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         for input_data in test_global_input_data_float64:
             S = pd.Series(input_data)
             result_ref = test_impl(S)
@@ -2620,7 +2623,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             return S.notna()
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         for input_data in test_global_input_data_integer64:
             S = pd.Series(input_data)
             result_ref = test_impl(S)
@@ -2632,7 +2635,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             return S.notna()
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         for input_data in test_global_input_data_numeric:
             S = pd.Series(input_data)
             result_ref = test_impl(S)
@@ -2643,7 +2646,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             return S.notna()
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         input_data = test_global_input_data_unicode_kind4
         S = pd.Series(input_data)
         result_ref = test_impl(S)
@@ -2653,7 +2656,7 @@ class TestSeries(unittest.TestCase):
     def test_series_str_notna(self):
         def test_impl(S):
             return S.notna()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series(['aa', None, 'c', 'cccd'])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -2661,7 +2664,7 @@ class TestSeries(unittest.TestCase):
     def test_series_str_isna1(self):
         def test_impl(S):
             return S.isna()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series(['aa', None, 'c', 'cccd'])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -2670,7 +2673,7 @@ class TestSeries(unittest.TestCase):
     def test_series_dt_isna1(self):
         def test_impl(S):
             return S.isna()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([pd.NaT, pd.Timestamp('1970-12-01'), pd.Timestamp('2012-07-25')])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -2679,7 +2682,7 @@ class TestSeries(unittest.TestCase):
         def test_impl():
             series = pd.Series([1., np.nan, -1., 0., min_float64, max_float64])
             return series.nlargest(4)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         if hpat.config.config_pipeline_hpat_default:
             np.testing.assert_array_equal(test_impl(), hpat_func())
@@ -2689,7 +2692,7 @@ class TestSeries(unittest.TestCase):
     def test_series_nlargest_unboxing(self):
         def test_impl(series, n):
             return series.nlargest(n)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         for data in test_global_input_data_numeric + [[]]:
             series = pd.Series(data * 3)
@@ -2711,7 +2714,7 @@ class TestSeries(unittest.TestCase):
             df = pq.read_table('kde.parquet').to_pandas()
             S = df.points
             return S.nlargest(4)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         if hpat.config.config_pipeline_hpat_default:
             np.testing.assert_array_equal(test_impl(), hpat_func())
@@ -2725,7 +2728,7 @@ class TestSeries(unittest.TestCase):
     def test_series_nlargest_full(self):
         def test_impl(series, n, keep):
             return series.nlargest(n, keep)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         keep = 'first'
         for data in test_global_input_data_numeric + [[]]:
@@ -2738,7 +2741,7 @@ class TestSeries(unittest.TestCase):
     def test_series_nlargest_index(self):
         def test_impl(series, n):
             return series.nlargest(n)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         # TODO: check data == [] after index is fixed
         for data in test_global_input_data_numeric:
@@ -2765,7 +2768,7 @@ class TestSeries(unittest.TestCase):
 
         def test_impl(series, n, keep):
             return series.nlargest(n, keep)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         series = pd.Series(test_global_input_data_float64[0])
         for n, ntype in [(True, types.boolean), (None, types.none),
@@ -2789,7 +2792,7 @@ class TestSeries(unittest.TestCase):
 
         def test_impl(series, n, keep):
             return series.nlargest(n, keep)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         series = pd.Series(test_global_input_data_float64[0])
         for keep in ['last', 'all', '']:
@@ -2805,7 +2808,7 @@ class TestSeries(unittest.TestCase):
         def test_impl():
             series = pd.Series([1., np.nan, -1., 0., min_float64, max_float64])
             return series.nsmallest(4)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         if hpat.config.config_pipeline_hpat_default:
             np.testing.assert_array_equal(test_impl(), hpat_func())
@@ -2815,7 +2818,7 @@ class TestSeries(unittest.TestCase):
     def test_series_nsmallest_unboxing(self):
         def test_impl(series, n):
             return series.nsmallest(n)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         for data in test_global_input_data_numeric + [[]]:
             series = pd.Series(data * 3)
@@ -2837,7 +2840,7 @@ class TestSeries(unittest.TestCase):
             df = pq.read_table('kde.parquet').to_pandas()
             S = df.points
             return S.nsmallest(4)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         if hpat.config.config_pipeline_hpat_default:
             np.testing.assert_array_equal(test_impl(), hpat_func())
@@ -2851,7 +2854,7 @@ class TestSeries(unittest.TestCase):
     def test_series_nsmallest_full(self):
         def test_impl(series, n, keep):
             return series.nsmallest(n, keep)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         keep = 'first'
         for data in test_global_input_data_numeric + [[]]:
@@ -2864,7 +2867,7 @@ class TestSeries(unittest.TestCase):
     def test_series_nsmallest_index(self):
         def test_impl(series, n):
             return series.nsmallest(n)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         # TODO: check data == [] after index is fixed
         for data in test_global_input_data_numeric:
@@ -2891,7 +2894,7 @@ class TestSeries(unittest.TestCase):
 
         def test_impl(series, n, keep):
             return series.nsmallest(n, keep)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         series = pd.Series(test_global_input_data_float64[0])
         for n, ntype in [(True, types.boolean), (None, types.none),
@@ -2915,7 +2918,7 @@ class TestSeries(unittest.TestCase):
 
         def test_impl(series, n, keep):
             return series.nsmallest(n, keep)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         series = pd.Series(test_global_input_data_float64[0])
         for keep in ['last', 'all', '']:
@@ -2930,7 +2933,7 @@ class TestSeries(unittest.TestCase):
     def test_series_head1(self):
         def test_impl(S):
             return S.head(4)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         m = 100
         np.random.seed(0)
@@ -2941,7 +2944,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies default head method for non-distributed pass of Series with no index'''
         def test_impl(S):
             return S.head()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         m = 100
         np.random.seed(0)
@@ -2953,7 +2956,7 @@ class TestSeries(unittest.TestCase):
         def test_impl():
             S = pd.Series([6, 9, 2, 3, 6, 4, 5], [8, 1, 6, 0, 9, 1, 3])
             return S.head(3)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         pd.testing.assert_series_equal(hpat_func(), test_impl())
 
@@ -2962,7 +2965,7 @@ class TestSeries(unittest.TestCase):
         def test_impl():
             S = pd.Series([6, 9, 2, 3, 6, 4, 5], ['a', 'ab', 'abc', 'c', 'f', 'hh', ''])
             return S.head(3)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         pd.testing.assert_series_equal(hpat_func(), test_impl())
 
@@ -2970,7 +2973,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies head method for non-distributed pass of Series with integer index'''
         def test_impl(S):
             return S.head(3)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([6, 9, 2, 3, 6, 4, 5], [8, 1, 6, 0, 9, 1, 3])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -2980,7 +2983,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies head method for non-distributed pass of Series with string index'''
         def test_impl(S):
             return S.head(3)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([6, 9, 2, 4, 6, 4, 5], ['a', 'ab', 'abc', 'c', 'f', 'hh', ''])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -2990,7 +2993,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             return S.head(7)
 
-        hpat_func = hpat.jit(distributed={'S'})(test_impl)
+        hpat_func = self.jit(distributed={'S'})(test_impl)
 
         # need to test different lenghts, as head's size is fixed and implementation
         # depends on relation of size of the data per processor to output data size
@@ -3004,7 +3007,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies head method for distributed Series with integer index'''
         def test_impl(S):
             return S.head(3)
-        hpat_func = hpat.jit(distributed={'S'})(test_impl)
+        hpat_func = self.jit(distributed={'S'})(test_impl)
 
         S = pd.Series([6, 9, 2, 3, 6, 4, 5], [8, 1, 6, 0, 9, 1, 3])
         start, end = get_start_end(len(S))
@@ -3016,7 +3019,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies head method for distributed Series with string index'''
         def test_impl(S):
             return S.head(3)
-        hpat_func = hpat.jit(distributed={'S'})(test_impl)
+        hpat_func = self.jit(distributed={'S'})(test_impl)
 
         S = pd.Series([6, 9, 2, 3, 6, 4, 5], ['a', 'ab', 'abc', 'c', 'f', 'hh', ''])
         start, end = get_start_end(len(S))
@@ -3026,7 +3029,7 @@ class TestSeries(unittest.TestCase):
     def test_series_head_noidx_float(self):
         def test_impl(S, n):
             return S.head(n)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         for input_data in test_global_input_data_float64:
             S = pd.Series(input_data)
             for n in [-1, 0, 2, 3]:
@@ -3038,7 +3041,7 @@ class TestSeries(unittest.TestCase):
     def test_series_head_noidx_int(self):
         def test_impl(S, n):
             return S.head(n)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         for input_data in test_global_input_data_integer64:
             S = pd.Series(input_data)
             for n in [-1, 0, 2, 3]:
@@ -3050,7 +3053,7 @@ class TestSeries(unittest.TestCase):
     def test_series_head_noidx_num(self):
         def test_impl(S, n):
             return S.head(n)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         for input_data in test_global_input_data_numeric:
             S = pd.Series(input_data)
             for n in [-1, 0, 2, 3]:
@@ -3062,7 +3065,7 @@ class TestSeries(unittest.TestCase):
     def test_series_head_noidx_str(self):
         def test_impl(S, n):
             return S.head(n)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         input_data = test_global_input_data_unicode_kind4
         S = pd.Series(input_data)
         for n in [-1, 0, 2, 3]:
@@ -3078,7 +3081,7 @@ class TestSeries(unittest.TestCase):
         def test_impl_param(S, n):
             return S.head(n)
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         data_test = [[6, 6, 2, 1, 3, 3, 2, 1, 2],
                      [1.1, 0.3, 2.1, 1, 3, 0.3, 2.1, 1.1, 2.2],
@@ -3096,7 +3099,7 @@ class TestSeries(unittest.TestCase):
                 result = hpat_func(S)
                 pd.testing.assert_series_equal(result, result_ref)
 
-                hpat_func_param1 = hpat.jit(test_impl_param)
+                hpat_func_param1 = self.jit(test_impl_param)
 
                 for param1 in [1, 3, 7]:
                     result_param1_ref = test_impl_param(S, param1)
@@ -3107,7 +3110,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies median implementation for float and integer series of random data'''
         def test_impl(S):
             return S.median()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         m = 100
         np.random.seed(0)
@@ -3131,7 +3134,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies median implementation with default skipna=True argument on a series with NA values'''
         def test_impl(S):
             return S.median()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([2., 3., 5., np.nan, 5., 6., 7.])
         self.assertEqual(hpat_func(S), test_impl(S))
@@ -3142,7 +3145,7 @@ class TestSeries(unittest.TestCase):
         '''Verifies median implementation with skipna=False on a series with NA values'''
         def test_impl(S):
             return S.median(skipna=False)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         # np.inf is not NaN, so verify that a correct number is returned
         S1 = pd.Series([2., 3., 5., np.inf, 5., 6., 7.])
@@ -3161,7 +3164,7 @@ class TestSeries(unittest.TestCase):
             df = pq.read_table('kde.parquet').to_pandas()
             S = df.points
             return S.median()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         self.assertEqual(hpat_func(), test_impl())
         self.assertEqual(count_array_REPs(), 0)
@@ -3176,14 +3179,14 @@ class TestSeries(unittest.TestCase):
             df = pq.read_table('kde.parquet').to_pandas()
             S = df.points
             return S.argsort().values
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         np.testing.assert_array_equal(hpat_func(), test_impl())
 
     def test_series_idxmin1(self):
         def test_impl(A):
             return A.idxmin()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         np.random.seed(0)
@@ -3193,7 +3196,7 @@ class TestSeries(unittest.TestCase):
     def test_series_idxmin_str(self):
         def test_impl(S):
             return S.idxmin()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([8, 6, 34, np.nan], ['a', 'ab', 'abc', 'c'])
         self.assertEqual(hpat_func(S), test_impl(S))
@@ -3203,7 +3206,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             return S.idxmin(skipna=False)
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([8, 6, 34, np.nan], ['a', 'ab', 'abc', 'c'])
         self.assertEqual(hpat_func(S), test_impl(S))
@@ -3211,7 +3214,7 @@ class TestSeries(unittest.TestCase):
     def test_series_idxmin_no(self):
         def test_impl(S):
             return S.idxmin()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([8, 6, 34, np.nan])
         self.assertEqual(hpat_func(S), test_impl(S))
@@ -3219,7 +3222,7 @@ class TestSeries(unittest.TestCase):
     def test_series_idxmin_int(self):
         def test_impl(S):
             return S.idxmin()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([1, 2, 3], [4, 45, 14])
         self.assertEqual(hpat_func(S), test_impl(S))
@@ -3228,7 +3231,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             return S.idxmin()
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         data_test = [[6, 6, 2, 1, 3, 3, 2, 1, 2],
                      [1.1, 0.3, 2.1, 1, 3, 0.3, 2.1, 1.1, 2.2],
@@ -3248,7 +3251,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             return S.idxmin()
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         data_test = [[6, 6, 2, 1, 3, 3, 2, 1, 2],
                      [1.1, 0.3, 2.1, 1, 3, 0.3, 2.1, 1.1, 2.2],
@@ -3270,7 +3273,7 @@ class TestSeries(unittest.TestCase):
     def test_series_idxmax1(self):
         def test_impl(A):
             return A.idxmax()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         np.random.seed(0)
@@ -3282,7 +3285,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             return S.idxmax(skipna=False)
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([8, 6, 34, np.nan], ['a', 'ab', 'abc', 'c'])
         self.assertEqual(hpat_func(S), test_impl(S))
@@ -3291,7 +3294,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             return S.idxmax()
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         data_test = [[6, 6, 2, 1, 3, 3, 2, 1, 2],
                      [1.1, 0.3, 2.1, 1, 3, 0.3, 2.1, 1.1, 2.2],
@@ -3311,7 +3314,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             return S.idxmax()
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         data_test = [[6, 6, 2, 1, 3, 3, 2, 1, 2],
                      [1.1, 0.3, 2.1, 1, 3, 0.3, 2.1, 1.1, 2.2],
@@ -3333,7 +3336,7 @@ class TestSeries(unittest.TestCase):
     def test_series_sort_values1(self):
         def test_impl(A):
             return A.sort_values()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         np.random.seed(0)
@@ -3343,7 +3346,7 @@ class TestSeries(unittest.TestCase):
     def test_series_sort_values2(self):
         def test_impl(S):
             return S.sort_values(ascending=False)
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series(['a', 'd', 'r', 'cc'])
         pd.testing.assert_series_equal(test_impl(S), hpat_func(S))
@@ -3352,7 +3355,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(A, B):
             S = pd.Series(A, B)
             return S.sort_values()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         n = 11
         np.random.seed(0)
@@ -3366,7 +3369,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(series, ascending, kind):
             return series.sort_values(axis=0, ascending=ascending, inplace=False, kind=kind, na_position='last')
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         all_data = test_global_input_data_numeric + [test_global_input_data_unicode_kind1]
 
@@ -3383,7 +3386,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(series, ascending, kind):
             return series.sort_values(axis=0, ascending=ascending, inplace=False, kind=kind, na_position='last')
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         all_data = [test_global_input_data_unicode_kind1]
 
@@ -3399,7 +3402,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(series, ascending, kind):
             return series.sort_values(axis=0, ascending=ascending, inplace=False, kind=kind, na_position='last')
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         all_data = test_global_input_data_numeric + [test_global_input_data_unicode_kind1]
 
@@ -3420,7 +3423,7 @@ class TestSeries(unittest.TestCase):
             df = pq.read_table('kde.parquet').to_pandas()
             S = df.points
             return S.sort_values()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         np.testing.assert_array_equal(hpat_func(), test_impl())
 
@@ -3429,14 +3432,14 @@ class TestSeries(unittest.TestCase):
             series = pd.Series([1.0, np.nan, -1.0, 0.0, 5e-324])
             return series.shift()
 
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
         pd.testing.assert_series_equal(cfunc(), pyfunc())
 
     def test_series_shift_unboxing(self):
         def pyfunc(series):
             return series.shift()
 
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
         for data in test_global_input_data_float64:
             series = pd.Series(data)
             pd.testing.assert_series_equal(cfunc(series), pyfunc(series))
@@ -3445,7 +3448,7 @@ class TestSeries(unittest.TestCase):
         def pyfunc(series, periods, freq, axis, fill_value):
             return series.shift(periods=periods, freq=freq, axis=axis, fill_value=fill_value)
 
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
         freq = None
         axis = 0
         for data in test_global_input_data_float64:
@@ -3460,7 +3463,7 @@ class TestSeries(unittest.TestCase):
         def pyfunc(series):
             return series.shift()
 
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
         series = pd.Series(test_global_input_data_unicode_kind4)
         with self.assertRaises(TypingError) as raises:
             cfunc(series)
@@ -3471,7 +3474,7 @@ class TestSeries(unittest.TestCase):
         def pyfunc(series, fill_value):
             return series.shift(fill_value=fill_value)
 
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
         series = pd.Series(test_global_input_data_float64[0])
         with self.assertRaises(TypingError) as raises:
             cfunc(series, fill_value='unicode')
@@ -3482,7 +3485,7 @@ class TestSeries(unittest.TestCase):
         def pyfunc(series, freq, axis):
             return series.shift(freq=freq, axis=axis)
 
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
         series = pd.Series(test_global_input_data_float64[0])
         with self.assertRaises(TypingError) as raises:
             cfunc(series, freq='12H', axis=0)
@@ -3498,7 +3501,7 @@ class TestSeries(unittest.TestCase):
     def test_series_shift_index_str(self):
         def test_impl(S):
             return S.shift()
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([np.nan, 2., 3., 5., np.nan, 6., 7.], index=['a', 'b', 'c', 'd', 'e', 'f', 'g'])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -3508,7 +3511,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             return S.shift()
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         S = pd.Series([np.nan, 2., 3., 5., np.nan, 6., 7.], index=[1, 2, 3, 4, 5, 6, 7])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
@@ -3518,7 +3521,7 @@ class TestSeries(unittest.TestCase):
             A = pd.Series([1, 2, 3], index=['A', 'C', 'B'])
             return A.index
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         np.testing.assert_array_equal(hpat_func(), test_impl())
 
     def test_series_index2(self):
@@ -3526,7 +3529,7 @@ class TestSeries(unittest.TestCase):
             A = pd.Series([1, 2, 3], index=[0, 1, 2])
             return A.index
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         np.testing.assert_array_equal(hpat_func(), test_impl())
 
     def test_series_index3(self):
@@ -3534,7 +3537,7 @@ class TestSeries(unittest.TestCase):
             A = pd.Series([1, 2, 3])
             return A.index
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         np.testing.assert_array_equal(hpat_func(), test_impl())
 
     def test_series_take_index_default(self):
@@ -3543,7 +3546,7 @@ class TestSeries(unittest.TestCase):
             indices = [1, 3]
             return series.take(indices)
 
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
         ref_result = pyfunc()
         result = cfunc()
         pd.testing.assert_series_equal(ref_result, result)
@@ -3552,7 +3555,7 @@ class TestSeries(unittest.TestCase):
         def pyfunc(series, indices):
             return series.take(indices)
 
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
         series = pd.Series([1.0, 13.0, 9.0, -1.0, 7.0])
         indices = [1, 3]
         ref_result = pyfunc(series, indices)
@@ -3565,7 +3568,7 @@ class TestSeries(unittest.TestCase):
             indices = [1, 3]
             return series.take(indices)
 
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
         ref_result = pyfunc()
         result = cfunc()
         pd.testing.assert_series_equal(ref_result, result)
@@ -3574,7 +3577,7 @@ class TestSeries(unittest.TestCase):
         def pyfunc(series, indices):
             return series.take(indices)
 
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
         series = pd.Series([1.0, 13.0, 9.0, -1.0, 7.0], index=[3, 0, 4, 2, 1])
         indices = [1, 3]
         ref_result = pyfunc(series, indices)
@@ -3587,7 +3590,7 @@ class TestSeries(unittest.TestCase):
             indices = [1, 3]
             return series.take(indices)
 
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
         ref_result = pyfunc()
         result = cfunc()
         pd.testing.assert_series_equal(ref_result, result)
@@ -3596,7 +3599,7 @@ class TestSeries(unittest.TestCase):
         def pyfunc(series, indices):
             return series.take(indices)
 
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
         series = pd.Series([1.0, 13.0, 9.0, -1.0, 7.0], index=['test', 'series', 'take', 'str', 'index'])
         indices = [1, 3]
         ref_result = pyfunc(series, indices)
@@ -3608,7 +3611,7 @@ class TestSeries(unittest.TestCase):
             return [i for i in A]
 
         A = pd.Series([3, 2, 1, 5, 4])
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         np.testing.assert_array_equal(hpat_func(A), test_impl(A))
 
     def test_series_iterator_float(self):
@@ -3616,7 +3619,7 @@ class TestSeries(unittest.TestCase):
             return [i for i in A]
 
         A = pd.Series([0.3, 0.2222, 0.1756, 0.005, 0.4])
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         np.testing.assert_array_equal(hpat_func(A), test_impl(A))
 
     def test_series_iterator_boolean(self):
@@ -3624,7 +3627,7 @@ class TestSeries(unittest.TestCase):
             return [i for i in A]
 
         A = pd.Series([True, False])
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         np.testing.assert_array_equal(hpat_func(A), test_impl(A))
 
     def test_series_iterator_string(self):
@@ -3632,7 +3635,7 @@ class TestSeries(unittest.TestCase):
             return [i for i in A]
 
         A = pd.Series(['a', 'ab', 'abc', '', 'dddd'])
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         np.testing.assert_array_equal(hpat_func(A), test_impl(A))
 
     def test_series_iterator_one_value(self):
@@ -3640,7 +3643,7 @@ class TestSeries(unittest.TestCase):
             return [i for i in A]
 
         A = pd.Series([5])
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         np.testing.assert_array_equal(hpat_func(A), test_impl(A))
 
     @unittest.skip("Fails when NUMA_PES>=2 due to unimplemented sync of such construction after distribution")
@@ -3649,7 +3652,7 @@ class TestSeries(unittest.TestCase):
             A = pd.Series([3, 2, 1, 5, 4])
             return [i for i in A]
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         np.testing.assert_array_equal(hpat_func(), test_impl())
 
     def test_series_iterator_empty(self):
@@ -3657,7 +3660,7 @@ class TestSeries(unittest.TestCase):
             return [i for i in A]
 
         A = pd.Series([np.int64(x) for x in range(0)])
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         np.testing.assert_array_equal(hpat_func(A), test_impl(A))
 
     def test_series_default_index(self):
@@ -3665,7 +3668,7 @@ class TestSeries(unittest.TestCase):
             A = pd.Series([3, 2, 1, 5, 4])
             return A.index
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         np.testing.assert_array_equal(hpat_func(), test_impl())
 
     @unittest.skip("Implement drop_duplicates for Series")
@@ -3674,7 +3677,7 @@ class TestSeries(unittest.TestCase):
             A = pd.Series(['lama', 'cow', 'lama', 'beetle', 'lama', 'hippo'])
             return A.drop_duplicates()
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         pd.testing.assert_series_equal(hpat_func(), test_impl())
 
     def test_series_quantile(self):
@@ -3682,7 +3685,7 @@ class TestSeries(unittest.TestCase):
             A = pd.Series([1, 2.5, .5, 3, 5])
             return A.quantile()
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         np.testing.assert_equal(hpat_func(), test_impl())
 
     @unittest.skipIf(hpat.config.config_pipeline_hpat_default, "Series.quantile() parameter as a list unsupported")
@@ -3691,7 +3694,7 @@ class TestSeries(unittest.TestCase):
             return S.quantile(param1)
 
         S = pd.Series(np.random.ranf(100))
-        hpat_func = hpat.jit(test_series_quantile_q_vector_impl)
+        hpat_func = self.jit(test_series_quantile_q_vector_impl)
 
         param1 = [0.0, 0.25, 0.5, 0.75, 1.0]
         result_ref = test_series_quantile_q_vector_impl(S, param1)
@@ -3703,7 +3706,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             return S.unique()
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         S = pd.Series([2, 1, 3, 3])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
 
@@ -3711,7 +3714,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(S):
             return S.unique()
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
         n = 11
         S = pd.Series(np.arange(n))
         S[2] = 0
@@ -3722,7 +3725,7 @@ class TestSeries(unittest.TestCase):
             data = pd.Series(['aa', 'aa', 'b', 'b', 'cccc', 'dd', 'ddd', 'dd'])
             return data.unique()
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         # since the orider of the elements are diffrent - check count of elements only
         ref_result = test_impl().size
@@ -3735,7 +3738,7 @@ class TestSeries(unittest.TestCase):
             grouped = A.groupby(A, sort=False)
             return grouped.count()
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         ref_result = test_impl()
         result = hpat_func()
@@ -3748,7 +3751,7 @@ class TestSeries(unittest.TestCase):
             grouped = A.groupby(A)
             return [i for i in grouped]
 
-        hpat_func = hpat.jit(test_impl)
+        hpat_func = self.jit(test_impl)
 
         ref_result = test_impl()
         result = hpat_func()
@@ -3759,7 +3762,7 @@ class TestSeries(unittest.TestCase):
             series = pd.Series([1.0, np.nan, -1.0, 0.0, 5e-324])
             return series.std()
 
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
         ref_result = pyfunc()
         result = cfunc()
         np.testing.assert_equal(ref_result, result)
@@ -3770,7 +3773,7 @@ class TestSeries(unittest.TestCase):
         def pyfunc(series, skipna, ddof):
             return series.std(skipna=skipna, ddof=ddof)
 
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
         for data in test_global_input_data_numeric + [[]]:
             series = pd.Series(data)
             for ddof in [0, 1]:
@@ -3785,7 +3788,7 @@ class TestSeries(unittest.TestCase):
         def pyfunc(series):
             return series.std()
 
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
         series = pd.Series(test_global_input_data_unicode_kind4)
         with self.assertRaises(TypingError) as raises:
             cfunc(series)
@@ -3798,7 +3801,7 @@ class TestSeries(unittest.TestCase):
         def pyfunc(series, axis, level, numeric_only):
             return series.std(axis=axis, level=level, numeric_only=numeric_only)
 
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
         series = pd.Series(test_global_input_data_float64[0])
         msg = 'Method std(). Unsupported parameters. Given {}: {}'
         with self.assertRaises(TypingError) as raises:
@@ -3820,7 +3823,7 @@ class TestSeries(unittest.TestCase):
         def test_series_nunique_param1_impl(S, dropna):
             return S.nunique(dropna)
 
-        hpat_func = hpat.jit(test_series_nunique_impl)
+        hpat_func = self.jit(test_series_nunique_impl)
 
         the_same_string = "the same string"
         test_input_data = []
@@ -3862,7 +3865,7 @@ class TestSeries(unittest.TestCase):
                 SDC pipeline does not support parameter to Series.nunique(dropna=True)
                 """
 
-                hpat_func_param1 = hpat.jit(test_series_nunique_param1_impl)
+                hpat_func_param1 = self.jit(test_series_nunique_param1_impl)
 
                 for param1 in [True, False]:
                     result_param1_ref = test_series_nunique_param1_impl(S, param1)
@@ -3874,7 +3877,7 @@ class TestSeries(unittest.TestCase):
             series = pd.Series([1.0, np.nan, -1.0, 0.0, 5e-324])
             return series.var()
 
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
         np.testing.assert_equal(pyfunc(), cfunc())
 
     @unittest.skipIf(hpat.config.config_pipeline_hpat_default,
@@ -3883,7 +3886,7 @@ class TestSeries(unittest.TestCase):
         def pyfunc(series):
             return series.var()
 
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
         for data in test_global_input_data_numeric + [[]]:
             series = pd.Series(data)
             np.testing.assert_equal(pyfunc(series), cfunc(series))
@@ -3894,7 +3897,7 @@ class TestSeries(unittest.TestCase):
         def pyfunc(series, skipna, ddof):
             return series.var(skipna=skipna, ddof=ddof)
 
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
         for data in test_global_input_data_numeric + [[]]:
             series = pd.Series(data)
             for ddof in [0, 1]:
@@ -3909,7 +3912,7 @@ class TestSeries(unittest.TestCase):
         def pyfunc(series):
             return series.var()
 
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
         series = pd.Series(test_global_input_data_unicode_kind4)
         with self.assertRaises(TypingError) as raises:
             cfunc(series)
@@ -3922,7 +3925,7 @@ class TestSeries(unittest.TestCase):
         def pyfunc(series, axis, level, numeric_only):
             return series.var(axis=axis, level=level, numeric_only=numeric_only)
 
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
         series = pd.Series(test_global_input_data_float64[0])
         msg = 'Method var(). Unsupported parameters. Given {}: {}'
         with self.assertRaises(TypingError) as raises:
@@ -3941,7 +3944,7 @@ class TestSeries(unittest.TestCase):
         def test_series_count_impl(S):
             return S.count()
 
-        hpat_func = hpat.jit(test_series_count_impl)
+        hpat_func = self.jit(test_series_count_impl)
 
         the_same_string = "the same string"
         test_input_data = [[6, 6, 2, 1, 3, 3, 2, 1, 2],
@@ -3973,7 +3976,7 @@ class TestSeries(unittest.TestCase):
             return series.cumsum()
 
         pyfunc = test_impl
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
         pd.testing.assert_series_equal(pyfunc(), cfunc())
 
     @unittest.skipIf(hpat.config.config_pipeline_hpat_default,
@@ -3983,7 +3986,7 @@ class TestSeries(unittest.TestCase):
             return s.cumsum()
 
         pyfunc = test_impl
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
 
         for data in test_global_input_data_numeric + [[]]:
             series = pd.Series(data)
@@ -3996,7 +3999,7 @@ class TestSeries(unittest.TestCase):
             return s.cumsum(axis=axis, skipna=skipna)
 
         pyfunc = test_impl
-        cfunc = hpat.jit(pyfunc)
+        cfunc = self.jit(pyfunc)
 
         axis = None
         for data in test_global_input_data_numeric + [[]]:
@@ -4012,7 +4015,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(s):
             return s.cumsum()
 
-        cfunc = hpat.jit(test_impl)
+        cfunc = self.jit(test_impl)
         series = pd.Series(test_global_input_data_unicode_kind4)
         with self.assertRaises(TypingError) as raises:
             cfunc(series)
@@ -4025,7 +4028,7 @@ class TestSeries(unittest.TestCase):
         def test_impl(s, axis):
             return s.cumsum(axis=axis)
 
-        cfunc = hpat.jit(test_impl)
+        cfunc = self.jit(test_impl)
         series = pd.Series(test_global_input_data_float64[0])
         for axis in [0, 1]:
             with self.assertRaises(TypingError) as raises:
@@ -4039,7 +4042,7 @@ class TestSeries(unittest.TestCase):
         def test_series_cov_impl(S1, S2, min_periods=None):
             return S1.cov(S2, min_periods)
 
-        hpat_func = hpat.jit(test_series_cov_impl)
+        hpat_func = self.jit(test_series_cov_impl)
         test_input_data1 = [[.2, .0, .6, .2],
                             [.2, .0, .6, .2, .5, .6, .7, .8],
                             [],
@@ -4067,7 +4070,7 @@ class TestSeries(unittest.TestCase):
         def test_series_cov_impl(S1, S2, min_periods=None):
             return S1.cov(S2, min_periods=min_periods)
 
-        hpat_func = hpat.jit(test_series_cov_impl)
+        hpat_func = self.jit(test_series_cov_impl)
         S1 = pd.Series([.2, .0, .6, .2])
         S2 = pd.Series(['abcdefgh', 'a','abcdefg', 'ab', 'abcdef', 'abc'])
         S3 = pd.Series(['aaaaa', 'bbbb', 'ccc', 'dd', 'e'])
@@ -4089,7 +4092,7 @@ class TestSeries(unittest.TestCase):
         def test_series_cov_impl(S1, S2, min_periods=None):
             return S1.cov(S2, min_periods)
 
-        hpat_func = hpat.jit(test_series_cov_impl)
+        hpat_func = self.jit(test_series_cov_impl)
         S1 = pd.Series([.2, .0, .6, .2])
         S2 = pd.Series([.3, .6, .0, .1])
 


### PR DESCRIPTION
Fixes #256

For new tests for Series you should:
1. use `self.jit(...)` instead of `hpat.jit(...)`
2. Add test name to `hpat.tests.test_series._numba_not_supported_tests` only if it does not support numba.jit

Also, old Series tests should be revised for reasons why they do not support numba.jit. See `_numba_not_supported_tests` list.