### PR TITLE
WIP: interface for map-reduce style kernels

### DIFF
--- a/hpat/datatypes/hpat_pandas_series_functions.py
+++ b/hpat/datatypes/hpat_pandas_series_functions.py
@@ -36,7 +36,7 @@ import pandas
 
 from numba.errors import TypingError
 from numba.extending import overload, overload_method, overload_attribute
-from numba import types
+from numba import types, njit
 
 import hpat
 import hpat.datatypes.common_functions as common_functions
@@ -2898,7 +2898,6 @@ def hpat_pandas_series_median(self, axis=None, skipna=True, level=None, numeric_
 
     return hpat_pandas_series_median_impl
 
-
 @overload_method(SeriesType, 'argsort')
 def hpat_pandas_series_argsort(self, axis=0, kind='quicksort', order=None):
     """
@@ -2979,6 +2978,37 @@ def hpat_pandas_series_argsort(self, axis=0, kind='quicksort', order=None):
 
     return hpat_pandas_series_argsort_noidx_impl
 
+@njit
+def _sort_map_func(list1):
+    return numpy.sort(list1)
+
+@njit
+def _sort_reduce_func(list1, list2):
+    # TODO: proper NaNs handling
+    size_1 = len(list1)
+    size_2 = len(list2)
+    res = numpy.empty(size_1 + size_2, list1.dtype)
+    i, j, k = 0, 0, 0
+    while i < size_1 and j < size_2:
+        if list1[i] < list2[j]:
+            res[k] = list1[i]
+            i += 1
+        else:
+            res[k] = list2[j]
+            j += 1
+        k += 1
+
+    while i < size_1:
+        res[k] = list1[i]
+        i += 1
+        k += 1
+
+    while j < size_2:
+        res[k] = list2[j]
+        j += 1
+        k += 1
+
+    return res
 
 @overload_method(SeriesType, 'sort_values')
 def hpat_pandas_series_sort_values(self, axis=0, ascending=True, inplace=False, kind='quicksort', na_position='last'):
@@ -3062,7 +3092,10 @@ def hpat_pandas_series_sort_values(self, axis=0, ascending=True, inplace=False, 
             na = self.isna().sum()
             indices = numpy.arange(len(self._data))
             index_result = numpy.argsort(self._data, kind='mergesort')
-            result = numpy.sort(self._data)
+
+            result = common_functions.map_reduce_chunked(self._data, numpy.empty(0, self._data.dtype), _sort_map_func, _sort_reduce_func)
+            # result = numpy.sort(self._data)
+
             i = len(self._data) - na
             index_result[i:] = index_result[i:][::-1]
             if not ascending:

--- a/hpat/distributed.py
+++ b/hpat/distributed.py
@@ -106,6 +106,7 @@ distributed_run_extensions = {}
 dist_analysis = None
 fir_text = None
 
+_distribution_depth = int(os.getenv('SDC_DISTRIBUTION_DEPTH', '1'))
 
 @register_pass(mutates_CFG=True, analysis_only=False)
 class DistributedPass(FunctionPass):
@@ -1707,11 +1708,10 @@ class DistributedPassImpl(object):
         # stencil_accesses, neighborhood = get_stencil_accesses(
         #     parfor, self.state.typemap)
 
-        dist_depth = 0
-
-        if depth >= dist_depth:
+        global _distribution_depth
+        if depth >= _distribution_depth:
             # Do not distribute
-            if depth == dist_depth:
+            if depth == _distribution_depth:
                 parfor.no_sequential_lowering = True
             return [parfor]
 

--- a/hpat/distributed.py
+++ b/hpat/distributed.py
@@ -121,14 +121,7 @@ class DistributedPass(FunctionPass):
         pass
 
     def run_pass(self, state):
-        # print('XXXXXXXXXXXXXXXXXXXXXXXXXXX')
-        # state.func_ir.dump()
-        # print('YYYYYYYYYYYYYYYYYYYYYYYYYYY')
-        res = DistributedPassImpl(state).run_pass()
-        # print('XXXXXXXXXXXXXXXXXXXXXXXXXXX')
-        # state.func_ir.dump()
-        # print('YYYYYYYYYYYYYYYYYYYYYYYYYYY')
-        return res
+        return DistributedPassImpl(state).run_pass()
 
 class DistributedPassImpl(object):
     """The summary of the class should be here for example below is the summary line for this class
@@ -219,14 +212,12 @@ class DistributedPassImpl(object):
                                   self.state.typemap, self.state.calltypes, self.state.typingctx,
                                   self.state.targetctx, self)
                 elif isinstance(inst, Parfor):
-                    print('********** process parfor **********')
                     out_nodes = self._run_parfor(inst, namevar_table, depth)
                     # run dist pass recursively
                     p_blocks = wrap_parfor_blocks(inst)
                     # build_definitions(p_blocks, self.state.func_ir._definitions)
                     self._run_dist_pass(p_blocks, depth + 1)
                     unwrap_parfor_blocks(inst)
-                    print('********** process parfor end **********')
                 elif isinstance(inst, ir.Assign):
                     lhs = inst.target.name
                     rhs = inst.value
@@ -287,9 +278,6 @@ class DistributedPassImpl(object):
 
             if not replaced:
                 blocks[label].body = new_body
-                # print('******************** new_body')
-                # print('\n'.join([str(a) for a in new_body]))
-                # print('********************')
 
         return blocks
 
@@ -1725,7 +1713,7 @@ class DistributedPassImpl(object):
             return self._run_parfor_1D_Var(parfor, namevar_table)
 
         if self._dist_analysis.parfor_dists[parfor.id] != Distribution.OneD:
-            if True or debug_prints():  # pragma: no cover
+            if debug_prints():  # pragma: no cover
                 print("parfor " + str(parfor.id) + " not parallelized.")
             return [parfor]
 
@@ -1903,9 +1891,6 @@ class DistributedPassImpl(object):
         _, reductions = get_parfor_reductions(
             parfor, parfor.params, self.state.calltypes)
 
-        # print('aaaaaaaaaaaaaaaaaaa')
-        # parfor.dump()
-        # print('aaaaaaaaaaaaaaaaaaa')
         for reduce_varname, (init_val, reduce_nodes) in reductions.items():
             # print(len(reduce_nodes))
             # print('\n'.join([str(a) for a in reduce_nodes]))
@@ -2113,9 +2098,6 @@ class DistributedPassImpl(object):
         replace_arg_nodes(block, [reduce_var, op_var])
         dist_reduce_nodes = [op_assign] + block.body[:-3]
         dist_reduce_nodes[-1].target = reduce_var
-        # print('*****************************')
-        # print('\n'.join([str(a) for a in dist_reduce_nodes]))
-        # print('*****************************')
         return dist_reduce_nodes
 
     def _get_reduce_op(self, reduce_nodes):

--- a/hpat/distributed.py
+++ b/hpat/distributed.py
@@ -1892,8 +1892,6 @@ class DistributedPassImpl(object):
             parfor, parfor.params, self.state.calltypes)
 
         for reduce_varname, (init_val, reduce_nodes) in reductions.items():
-            # print(len(reduce_nodes))
-            # print('\n'.join([str(a) for a in reduce_nodes]))
             reduce_op = guard(self._get_reduce_op, reduce_nodes)
             # TODO: initialize reduction vars (arrays)
             reduce_var = namevar_table[reduce_varname]

--- a/hpat/distributed.py
+++ b/hpat/distributed.py
@@ -1709,9 +1709,9 @@ class DistributedPassImpl(object):
 
         dist_depth = 0
 
-        if depth > dist_depth:
+        if depth >= dist_depth:
             # Do not distribute
-            if depth == (dist_depth + 1):
+            if depth == dist_depth:
                 parfor.no_sequential_lowering = True
             return [parfor]
 


### PR DESCRIPTION
This PR adds new APIs to be used by pandas functions implementers to help parallelize theirs kernels:
* `map_reduce(arg, init_val, map_func, reduce_func)`
* `map_reduce_chunked(arg, init_val, map_func, reduce_func)`

Parameters:
* `arg` - list-like object (it can be python list, numpy array or any other object with similar interface)
* `init_val` - initial value
* `map_func` - map function which will be applied to each element/elements range in parallel (on different processes of on different nodes)
* `reduce_func` - reduction function to combine initial value and results from different processes/nodes

The difference between these two functions:
* `map_reduce` will apply map function to each element in range (map function must take single element and return single element) and then apply reduce function pairwise (reduce function must take two elements and return single element)
* `map_reduce_chunked` will apply map function to range of elements, belonging to current thread/node (map function must take range of elements as paramenter and return list/array as result) and then apply reduce to entire ranges (reduce function must take two ranges as parameters and return list/array)

You can also call any of these functions from inside map or reduce func to support nested parallelism.

These functions usable for both thread/mpi parallelism.

If you call them from numba `@njit` function they will be parallelized by numba buiilt-in parallelisation machinery.

If you call them from `@hpat.jit` they will be distributed by hpat parallelisation pass (doesn't work currently)

Wrote parallel series sorting (numpy.sort + hand-written merge) as example.

Current issues:
* Thread parallel sort isn't working due to numba  issue https://github.com/numba/numba/issues/4806
* MPI parallelisation doesn't work entirely (lot of issues, bigger one is that hpat support only very limited list of built-in functions (sum, mult, min, max) for parfor reductions)
* Parallel sort handles NaNs differently from `numpy.sort`, need to fix
* Threads/nodes count in `map_reduce_chunked` handcode as 4, will fix
* Proper documentation

The second part of this PR is distribution depth knob to (not-so)fine-tune nested parallelism between distribution and threading:
* New environment variable `SDC_DISTRIBUTION_DEPTH` controls how much nested parallel loops will be distributed by DistributionPass
* Distributed loops are any of newly introduced `map_reduce*` functions or manually written `prange` loops.
* Default value is `1` which means that only the most outer loop will be distributed by mpi, then next loop will parallelised by numba, and then all deeper loops will be executed sequentually (as numba doesn't support nested parallelisation)
* Set `SDC_DISTRIBUTION_DEPTH` to `0` to disable distribution.

```
# SDC_DISTRIBUTION_DEPTH=1
for i in prange(I) # distributed by DistributedPass
    for j in prange(J) # parallelised by numba
        for k in prange(K) # executed sequentually
```