### PR TITLE
Adding performance test for Series (A+B).sum()

### DIFF
--- a/sdc/tests/tests_perf/test_perf_series.py
+++ b/sdc/tests/tests_perf/test_perf_series.py
@@ -25,6 +25,7 @@
 # EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # *****************************************************************************
 import pandas as pd
+import numpy as np
 
 from sdc.tests.test_utils import *
 from sdc.tests.tests_perf.test_perf_base import *
@@ -215,6 +216,15 @@ def usecase_series_dropna(input_data):
     return finish_time - start_time, res
 
 
+def usecase_series_chain_add_and_sum(A, B):
+    start_time = time.time()
+    res = (A + B).sum()
+    finish_time = time.time()
+    res_time = finish_time - start_time
+
+    return res_time, res
+
+
 # python -m sdc.runtests sdc.tests.tests_perf.test_perf_series.TestSeriesMethods
 class TestSeriesMethods(TestBase):
     @classmethod
@@ -243,7 +253,8 @@ class TestSeriesMethods(TestBase):
             'series_median': [10 ** 8],
             'series_argsort': [10 ** 5],
             'series_sort_values': [10 ** 5],
-            'series_dropna': [2 * 10 ** 8]
+            'series_dropna': [2 * 10 ** 8],
+            'series_chain_add_and_sum': [20 * 10 ** 7, 25 * 10 ** 7, 30 * 10 ** 7],
         }
 
     def _test_series(self, pyfunc, name, input_data=None):
@@ -264,6 +275,28 @@ class TestSeriesMethods(TestBase):
 
             exec_times, _ = get_times(pyfunc, test_data, iter_number=self.iter_number)
             self.test_results.add(name, 'Reference', test_data.size, test_results=exec_times)
+
+    def _test_series_binary_operations(self, pyfunc, name, input_data=None):
+        np.random.seed(0)
+        hpat_func = sdc.jit(pyfunc)
+        for data_length in self.total_data_length[name]:
+
+            # TODO: replace with generic function to generate random sequence of floats
+            data1 = np.random.ranf(data_length)
+            data2 = np.random.ranf(data_length)
+            A = pd.Series(data1)
+            B = pd.Series(data2)
+
+            compile_results = calc_compilation(pyfunc, A, B, iter_number=self.iter_number)
+
+            # Warming up
+            hpat_func(A, B)
+
+            exec_times, boxing_times = get_times(hpat_func, A, B, iter_number=self.iter_number)
+            self.test_results.add(name, 'JIT', A.size, exec_times, boxing_times,
+                                  compile_results=compile_results, num_threads=self.num_threads)
+            exec_times, _ = get_times(pyfunc, A, B, iter_number=self.iter_number)
+            self.test_results.add(name, 'Reference', A.size, exec_times, num_threads=self.num_threads)
 
     def test_series_float_min(self):
         self._test_series(usecase_series_min, 'series_min')
@@ -333,3 +366,6 @@ class TestSeriesMethods(TestBase):
 
     def test_series_float_dropna(self):
         self._test_series(usecase_series_dropna, 'series_dropna')
+
+    def test_series_chain_add_and_sum(self):
+        self._test_series_binary_operations(usecase_series_chain_add_and_sum, 'series_chain_add_and_sum')


### PR DESCRIPTION
With the following test two observations were made (both require further investigation):
1. Changing NUMBA_NUM_THREADS env variable (TBB and default threading layer) has no impact on the execution times both in new-style and old-style implementations,
2. Old-style implementation is 1.5-2 times faster than the new-style impl.