### PR TITLE
Skip hanging tests in test_basic

### DIFF
--- a/sdc/tests/test_basic.py
+++ b/sdc/tests/test_basic.py
@@ -86,6 +86,7 @@ class BaseTest(TestCase):
 
 class TestBasic(BaseTest):
 
+    @skip_numba_jit("hang with numba.jit. ok with sdc.jit")
     def test_getitem(self):
         def test_impl(N):
             A = np.ones(N)
@@ -99,6 +100,7 @@ class TestBasic(BaseTest):
         self.assertEqual(count_array_REPs(), 0)
         self.assertEqual(count_parfor_REPs(), 0)
 
+    @skip_numba_jit("Failed in nopython mode pipeline (step: Preprocessing for parfors)")
     def test_setitem1(self):
         def test_impl(N):
             A = np.arange(10) + 1.0
@@ -111,6 +113,7 @@ class TestBasic(BaseTest):
         self.assertEqual(count_array_REPs(), 0)
         self.assertEqual(count_parfor_REPs(), 0)
 
+    @skip_numba_jit("Failed in nopython mode pipeline (step: Preprocessing for parfors)")
     def test_setitem2(self):
         def test_impl(N):
             A = np.arange(10) + 1.0
@@ -123,6 +126,7 @@ class TestBasic(BaseTest):
         self.assertEqual(count_array_REPs(), 0)
         self.assertEqual(count_parfor_REPs(), 0)
 
+    @skip_numba_jit("hang with numba.jit. ok with sdc.jit")
     def test_astype(self):
         def test_impl(N):
             return np.ones(N).astype(np.int32).sum()
@@ -152,6 +156,7 @@ class TestBasic(BaseTest):
         # self.assertEqual(count_array_REPs(), 0)
         # self.assertEqual(count_parfor_REPs(), 0)
 
+    @skip_numba_jit("hang with numba.jit. ok with sdc.jit")
     def test_inplace_binop(self):
         def test_impl(N):
             A = np.ones(N)
@@ -165,6 +170,7 @@ class TestBasic(BaseTest):
         self.assertEqual(count_array_REPs(), 0)
         self.assertEqual(count_parfor_REPs(), 0)
 
+    @skip_numba_jit("hang with numba.jit. ok with sdc.jit")
     def test_getitem_multidim(self):
         def test_impl(N):
             A = np.ones((N, 3))
@@ -178,6 +184,7 @@ class TestBasic(BaseTest):
         self.assertEqual(count_array_REPs(), 0)
         self.assertEqual(count_parfor_REPs(), 0)
 
+    @skip_numba_jit("Failed in nopython mode pipeline (step: Preprocessing for parfors)")
     def test_whole_slice(self):
         def test_impl(N):
             X = np.ones((N, 4))
@@ -190,6 +197,7 @@ class TestBasic(BaseTest):
         self.assertEqual(count_array_REPs(), 0)
         self.assertEqual(count_parfor_REPs(), 0)
 
+    @skip_numba_jit("hang with numba.jit. ok with sdc.jit")
     def test_strided_getitem(self):
         def test_impl(N):
             A = np.ones(N)
@@ -229,6 +237,7 @@ class TestBasic(BaseTest):
 
         pd.testing.assert_series_equal(self.jit(f)(), f())
 
+    @skip_numba_jit("Failed in nopython mode pipeline (step: Preprocessing for parfors)")
     def test_reduce(self):
         import sys
         dtypes = ['float32', 'float64', 'int32', 'int64']
@@ -423,6 +432,7 @@ class TestBasic(BaseTest):
         finally:
             sdc.distributed_analysis.auto_rebalance = False
 
+    @skip_numba_jit("Failed in nopython mode pipeline (step: Preprocessing for parfors)")
     def test_transpose(self):
         def test_impl(n):
             A = np.ones((30, 40, 50))

--- a/sdc/tests/test_hiframes.py
+++ b/sdc/tests/test_hiframes.py
@@ -44,7 +44,7 @@ from sdc.tests.test_base import TestCase
 from sdc.tests.test_utils import (count_array_REPs, count_parfor_REPs,
                                    count_parfor_OneDs, count_array_OneDs, dist_IR_contains,
                                    get_start_end,
-                                   skip_numba_jit)
+                                   skip_sdc_jit, skip_numba_jit)
 
 
 class TestHiFrames(TestCase):
@@ -424,6 +424,7 @@ class TestHiFrames(TestCase):
         pd.testing.assert_series_equal(
             hpat_func(df), test_impl(df), check_names=False)
 
+    @skip_sdc_jit("Could not get length of Series(StringArraySplitView)")
     @skip_numba_jit
     def test_str_split_filter(self):
         def test_impl(df):


### PR DESCRIPTION
This PR fixes #351. There are some difference between sdc.jit and numba.jit:
1. sdc.jit do not set parallel=True.