### PR TITLE
Import hooks for SDC implemented via overriding __import__

### DIFF
--- a/numba_sdc/__init__.py
+++ b/numba_sdc/__init__.py
@@ -1,0 +1,28 @@
+import sys
+import builtins
+
+
+def _init_extension():
+    '''Register Pandas classes and functions with Numba.
+
+    This entry_point is called by Numba when it initializes.
+    '''
+    if 'pandas' in sys.modules:
+        import sdc
+    else:
+        old_import = builtins.__import__
+        def new_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == 'pandas':
+                current_import = builtins.__import__
+                builtins.__import__ = old_import
+                import pandas
+                import sdc
+                builtins.__import__ = current_import
+            return old_import(name, globals, locals, fromlist, level)
+        builtins.__import__ = new_import
+
+        # class Finder:
+        #     def find_module(self, fullname, path=None):
+        #         if fullname.startswith('pandas'):
+        #             import sdc
+        # sys.meta_path.insert(0, Finder())

--- a/setup.py
+++ b/setup.py
@@ -423,7 +423,9 @@ setup(name='sdc',
       ext_modules=_ext_mods,
       entry_points={
           "numba_extensions": [
-              "init = sdc:_init_extension",
+            #   "init = sdc.numba_extension:_init_extension",
+            #   "init = sdc:_init_extension",
+              "init = numba_sdc:_init_extension",
           ],
       },
 )

--- a/test_import-hooks.py
+++ b/test_import-hooks.py
@@ -1,0 +1,91 @@
+# TODO: make it possible to run tests in group. Now it should be run one by one with:
+# pytest ./test_import-hooks.py::<test name>
+
+import sys
+
+
+def unload_sdc():
+    """Return to the state when sdc is not imported."""
+    for module in list(sys.modules.keys()):
+        if module.startswith('sdc'):
+            sys.modules.pop(module)
+
+
+def test_pandas_is_not_enought():
+    import pandas
+    assert 'sdc' not in sys.modules
+
+
+def test_numba_is_not_enought():
+    import numba
+    assert 'sdc' not in sys.modules
+
+
+def test_numba_and_pandas_is_not_enought():
+    import numba
+    import pandas
+    assert 'sdc' not in sys.modules
+
+
+def test_numba_and_pandas_and_compilation_is_enought():
+    import numba
+    import pandas
+
+    @numba.jit('int64()')
+    def f():
+        return 42
+
+    assert 'sdc' in sys.modules
+
+
+def test_pandas_after_compilation_is_ok():
+    unload_sdc()
+
+    import numba
+
+    # this variable blocks extension initialization more than once
+    assert not numba.entrypoints._already_initialized
+
+    @numba.jit('int64()')
+    def f():
+        return 42
+    assert numba.entrypoints._already_initialized
+    assert 'sdc' not in sys.modules
+
+    # If extensions initialized sdc module is loaded only if:
+    # 1. pandas is imported
+    import pandas
+    assert 'sdc' in sys.modules
+
+
+# Old test.
+
+# def test_sdc_loaded():
+#     unload_sdc()
+
+#     assert 'sdc' not in sys.modules
+
+#     import numba
+#     assert 'sdc' not in sys.modules
+
+#     @numba.jit
+#     def f():
+#         return 42
+#     assert 'sdc' not in sys.modules
+
+#     f.compile('int64()')
+#     assert 'sdc' not in sys.modules
+
+#     # Reset compilation for compiling again
+#     f.overloads.clear()
+#     # Reset _already_initialized for initializing extensions again
+#     numba.entrypoints._already_initialized = False
+
+#     # sdc module is loaded only if:
+#     # 1. pandas is imported
+#     # 2. compilation (or first run, or signature in numba.jit())
+#     import pandas
+#     assert 'sdc' not in sys.modules
+
+#     f.compile('int64()')
+#     assert 'sdc' in sys.modules


### PR DESCRIPTION
POC for import hooks for SDC:
Import SDC only if both numba and pandas are imported.