### PR TITLE
Add sdc_overload, sdc_overload_method, sdc_overload_attribute decorators

### DIFF
--- a/sdc/datatypes/hpat_pandas_dataframe_functions.py
+++ b/sdc/datatypes/hpat_pandas_dataframe_functions.py
@@ -37,9 +37,10 @@ from numba.extending import (overload, overload_method, overload_attribute)
 from numba.errors import TypingError
 
 from sdc.datatypes.hpat_pandas_dataframe_types import DataFrameType
+from sdc.utils import sdc_overload_method
 
 
-@overload_method(DataFrameType, 'count')
+@sdc_overload_method(DataFrameType, 'count')
 def sdc_pandas_dataframe_count(self, axis=0, level=None, numeric_only=False):
     """
     Pandas DataFrame method :meth:`pandas.DataFrame.count` implementation.

--- a/sdc/datatypes/hpat_pandas_series_functions.py
+++ b/sdc/datatypes/hpat_pandas_series_functions.py
@@ -47,7 +47,7 @@ from sdc.datatypes.hpat_pandas_stringmethods_types import StringMethodsType
 from sdc.hiframes.pd_series_ext import SeriesType
 from sdc.str_arr_ext import (StringArrayType, cp_str_list_to_array, num_total_chars, string_array_type,
                              str_arr_is_na, pre_alloc_string_array, str_arr_set_na)
-from sdc.utils import to_array, sdc_overload_method
+from sdc.utils import to_array, sdc_overload, sdc_overload_method
 
 
 @overload(operator.getitem)
@@ -748,7 +748,7 @@ def hpat_pandas_series_T(self):
     return hpat_pandas_series_T_impl
 
 
-@overload(len)
+@sdc_overload(len)
 def hpat_pandas_series_len(self):
     """
     Pandas Series operator :func:`len` implementation

--- a/sdc/datatypes/hpat_pandas_series_functions.py
+++ b/sdc/datatypes/hpat_pandas_series_functions.py
@@ -47,7 +47,7 @@ from sdc.datatypes.hpat_pandas_stringmethods_types import StringMethodsType
 from sdc.hiframes.pd_series_ext import SeriesType
 from sdc.str_arr_ext import (StringArrayType, cp_str_list_to_array, num_total_chars, string_array_type,
                              str_arr_is_na, pre_alloc_string_array, str_arr_set_na)
-from sdc.utils import to_array, sdc_overload, sdc_overload_method
+from sdc.utils import to_array, sdc_overload, sdc_overload_method, sdc_overload_attribute
 
 
 @sdc_overload(operator.getitem)
@@ -141,10 +141,10 @@ def hpat_pandas_series_getitem(self, idx):
     raise TypingError('{} The index must be an Integer, Slice or a pandas.series. Given: {}'.format(_func_name, idx))
 
 
-@overload_attribute(SeriesType, 'at')
-@overload_attribute(SeriesType, 'iat')
-@overload_attribute(SeriesType, 'iloc')
-@overload_attribute(SeriesType, 'loc')
+@sdc_overload_attribute(SeriesType, 'at')
+@sdc_overload_attribute(SeriesType, 'iat')
+@sdc_overload_attribute(SeriesType, 'iloc')
+@sdc_overload_attribute(SeriesType, 'loc')
 def hpat_pandas_series_iloc(self):
     """
     Pandas Series operators :attr:`pandas.Series.at`, :attr:`pandas.Series.iat`, :attr:`pandas.Series.iloc`, :attr:`pandas.Series.loc` implementation.
@@ -276,7 +276,7 @@ def hpat_pandas_series_nlargest(self, n=5, keep='first'):
     return hpat_pandas_series_nlargest_impl
 
 
-@overload_attribute(SeriesType, 'shape')
+@sdc_overload_attribute(SeriesType, 'shape')
 def hpat_pandas_series_shape(self):
     """
     Pandas Series attribute :attr:`pandas.Series.shape` implementation
@@ -371,7 +371,7 @@ def hpat_pandas_series_std(self, axis=None, skipna=None, level=None, ddof=1, num
     return hpat_pandas_series_std_impl
 
 
-@overload_attribute(SeriesType, 'values')
+@sdc_overload_attribute(SeriesType, 'values')
 def hpat_pandas_series_values(self):
     """
     Pandas Series attribute 'values' implementation.
@@ -586,7 +586,7 @@ def hpat_pandas_series_var(self, axis=None, skipna=None, level=None, ddof=1, num
     return hpat_pandas_series_var_impl
 
 
-@overload_attribute(SeriesType, 'index')
+@sdc_overload_attribute(SeriesType, 'index')
 def hpat_pandas_series_index(self):
     """
     Pandas Series attribute :attr:`pandas.Series.index` implementation
@@ -620,7 +620,7 @@ def hpat_pandas_series_index(self):
         return hpat_pandas_series_index_impl
 
 
-@overload_attribute(SeriesType, 'size')
+@sdc_overload_attribute(SeriesType, 'size')
 def hpat_pandas_series_size(self):
     """
     Pandas Series attribute :attr:`pandas.Series.size` implementation
@@ -651,7 +651,7 @@ def hpat_pandas_series_size(self):
     return hpat_pandas_series_size_impl
 
 
-@overload_attribute(SeriesType, 'str')
+@sdc_overload_attribute(SeriesType, 'str')
 def hpat_pandas_series_str(self):
     """
     Pandas Series attribute :attr:`pandas.Series.str` implementation
@@ -686,7 +686,7 @@ def hpat_pandas_series_str(self):
     return hpat_pandas_series_str_impl
 
 
-@overload_attribute(SeriesType, 'ndim')
+@sdc_overload_attribute(SeriesType, 'ndim')
 def hpat_pandas_series_ndim(self):
     """
     Pandas Series attribute :attr:`pandas.Series.ndim` implementation
@@ -717,7 +717,7 @@ def hpat_pandas_series_ndim(self):
     return hpat_pandas_series_ndim_impl
 
 
-@overload_attribute(SeriesType, 'T')
+@sdc_overload_attribute(SeriesType, 'T')
 def hpat_pandas_series_T(self):
     """
     Pandas Series attribute :attr:`pandas.Series.T` implementation

--- a/sdc/datatypes/hpat_pandas_series_functions.py
+++ b/sdc/datatypes/hpat_pandas_series_functions.py
@@ -50,7 +50,7 @@ from sdc.str_arr_ext import (StringArrayType, cp_str_list_to_array, num_total_ch
 from sdc.utils import to_array, sdc_overload, sdc_overload_method
 
 
-@overload(operator.getitem)
+@sdc_overload(operator.getitem)
 def hpat_pandas_series_getitem(self, idx):
     """
     Intel Scalable Dataframe Compiler User Guide
@@ -3727,7 +3727,7 @@ def hpat_pandas_series_pct_change(self, periods=1, fill_method='pad', limit=None
     return hpat_pandas_series_pct_change_impl
 
 
-@overload(operator.add)
+@sdc_overload(operator.add)
 def hpat_pandas_series_operator_add(self, other):
     """
     Pandas Series operator :attr:`pandas.Series.add` implementation

--- a/sdc/datatypes/hpat_pandas_series_functions.py
+++ b/sdc/datatypes/hpat_pandas_series_functions.py
@@ -47,7 +47,7 @@ from sdc.datatypes.hpat_pandas_stringmethods_types import StringMethodsType
 from sdc.hiframes.pd_series_ext import SeriesType
 from sdc.str_arr_ext import (StringArrayType, cp_str_list_to_array, num_total_chars, string_array_type,
                              str_arr_is_na, pre_alloc_string_array, str_arr_set_na)
-from sdc.utils import to_array
+from sdc.utils import to_array, sdc_overload_method
 
 
 @overload(operator.getitem)
@@ -174,7 +174,7 @@ def hpat_pandas_series_iloc(self):
     return hpat_pandas_series_iloc_impl
 
 
-@overload_method(SeriesType, 'nsmallest')
+@sdc_overload_method(SeriesType, 'nsmallest')
 def hpat_pandas_series_nsmallest(self, n=5, keep='first'):
     """
     Pandas Series method :meth:`pandas.Series.nsmallest` implementation.
@@ -224,7 +224,7 @@ def hpat_pandas_series_nsmallest(self, n=5, keep='first'):
     return hpat_pandas_series_nsmallest_impl
 
 
-@overload_method(SeriesType, 'nlargest')
+@sdc_overload_method(SeriesType, 'nlargest')
 def hpat_pandas_series_nlargest(self, n=5, keep='first'):
     """
     Pandas Series method :meth:`pandas.Series.nlargest` implementation.
@@ -303,7 +303,7 @@ def hpat_pandas_series_shape(self):
     return hpat_pandas_series_shape_impl
 
 
-@overload_method(SeriesType, 'std')
+@sdc_overload_method(SeriesType, 'std')
 def hpat_pandas_series_std(self, axis=None, skipna=None, level=None, ddof=1, numeric_only=None):
     """
     Pandas Series method :meth:`pandas.Series.std` implementation.
@@ -394,7 +394,7 @@ def hpat_pandas_series_values(self):
     return hpat_pandas_series_values_impl
 
 
-@overload_method(SeriesType, 'value_counts')
+@sdc_overload_method(SeriesType, 'value_counts')
 def hpat_pandas_series_value_counts(self, normalize=False, sort=True, ascending=False, bins=None, dropna=True):
     """
     Pandas Series method :meth:`pandas.Series.value_counts` implementation.
@@ -506,7 +506,7 @@ def hpat_pandas_series_value_counts(self, normalize=False, sort=True, ascending=
     return hpat_pandas_series_value_counts_number_impl
 
 
-@overload_method(SeriesType, 'var')
+@sdc_overload_method(SeriesType, 'var')
 def hpat_pandas_series_var(self, axis=None, skipna=None, level=None, ddof=1, numeric_only=None):
     """
     Pandas Series method :meth:`pandas.Series.var` implementation.
@@ -778,7 +778,7 @@ def hpat_pandas_series_len(self):
     return hpat_pandas_series_len_impl
 
 
-@overload_method(SeriesType, 'astype')
+@sdc_overload_method(SeriesType, 'astype')
 def hpat_pandas_series_astype(self, dtype, copy=True, errors='raise'):
     """
     Pandas Series method :meth:`pandas.Series.astype` implementation.
@@ -881,7 +881,7 @@ def hpat_pandas_series_astype(self, dtype, copy=True, errors='raise'):
         return hpat_pandas_series_astype_no_modify_impl
 
 
-@overload_method(SeriesType, 'shift')
+@sdc_overload_method(SeriesType, 'shift')
 def hpat_pandas_series_shift(self, periods=1, freq=None, axis=0, fill_value=None):
     """
     Pandas Series method :meth:`pandas.Series.shift` implementation.
@@ -954,7 +954,7 @@ def hpat_pandas_series_shift(self, periods=1, freq=None, axis=0, fill_value=None
     return hpat_pandas_series_shift_impl
 
 
-@overload_method(SeriesType, 'isin')
+@sdc_overload_method(SeriesType, 'isin')
 def hpat_pandas_series_isin(self, values):
     """
     Pandas Series method :meth:`pandas.Series.isin` implementation.
@@ -988,7 +988,7 @@ def hpat_pandas_series_isin(self, values):
     return hpat_pandas_series_isin_impl
 
 
-@overload_method(SeriesType, 'append')
+@sdc_overload_method(SeriesType, 'append')
 def hpat_pandas_series_append(self, to_append, ignore_index=False, verify_integrity=False):
     """
     Pandas Series method :meth:`pandas.Series.append` implementation.
@@ -1077,7 +1077,7 @@ def hpat_pandas_series_append(self, to_append, ignore_index=False, verify_integr
         return hpat_pandas_series_append_ignore_index_impl
 
 
-@overload_method(SeriesType, 'copy')
+@sdc_overload_method(SeriesType, 'copy')
 def hpat_pandas_series_copy(self, deep=True):
     """
     Pandas Series method :meth:`pandas.Series.copy` implementation.
@@ -1122,7 +1122,7 @@ def hpat_pandas_series_copy(self, deep=True):
             return hpat_pandas_series_copy_impl
 
 
-@overload_method(SeriesType, 'corr')
+@sdc_overload_method(SeriesType, 'corr')
 def hpat_pandas_series_corr(self, other, method='pearson', min_periods=None):
     """
     Pandas Series method :meth:`pandas.Series.corr` implementation.
@@ -1203,7 +1203,7 @@ def hpat_pandas_series_corr(self, other, method='pearson', min_periods=None):
     return hpat_pandas_series_corr_impl
 
 
-@overload_method(SeriesType, 'head')
+@sdc_overload_method(SeriesType, 'head')
 def hpat_pandas_series_head(self, n=5):
     """
     Pandas Series method :meth:`pandas.Series.head` implementation.
@@ -1241,7 +1241,7 @@ def hpat_pandas_series_head(self, n=5):
         return hpat_pandas_series_head_index_impl
 
 
-@overload_method(SeriesType, 'groupby')
+@sdc_overload_method(SeriesType, 'groupby')
 def hpat_pandas_series_groupby(
         self,
         by=None,
@@ -1312,8 +1312,8 @@ def hpat_pandas_series_groupby(
     return hpat_pandas_series_groupby_impl
 
 
-@overload_method(SeriesType, 'isnull')
-@overload_method(SeriesType, 'isna')
+@sdc_overload_method(SeriesType, 'isnull')
+@sdc_overload_method(SeriesType, 'isna')
 def hpat_pandas_series_isna(self):
     """
     Pandas Series method :meth:`pandas.Series.isna` and :meth:`pandas.Series.isnull` implementation.
@@ -1365,7 +1365,7 @@ def hpat_pandas_series_isna(self):
         return hpat_pandas_series_isna_impl
 
 
-@overload_method(SeriesType, 'notna')
+@sdc_overload_method(SeriesType, 'notna')
 def hpat_pandas_series_notna(self):
     """
     Pandas Series method :meth:`pandas.Series.notna` implementation.
@@ -1404,7 +1404,7 @@ def hpat_pandas_series_notna(self):
         return hpat_pandas_series_notna_impl
 
 
-@overload_method(SeriesType, 'ne')
+@sdc_overload_method(SeriesType, 'ne')
 def hpat_pandas_series_ne(self, other, level=None, fill_value=None, axis=0):
     """
     Pandas Series method :meth:`pandas.Series.ne` implementation.
@@ -1466,7 +1466,7 @@ def hpat_pandas_series_ne(self, other, level=None, fill_value=None, axis=0):
             _func_name, self, other))
 
 
-@overload_method(SeriesType, 'add')
+@sdc_overload_method(SeriesType, 'add')
 def hpat_pandas_series_add(self, other, level=None, fill_value=None, axis=0):
     """
     Pandas Series method :meth:`pandas.Series.add` implementation.
@@ -1528,7 +1528,7 @@ def hpat_pandas_series_add(self, other, level=None, fill_value=None, axis=0):
             _func_name, self, other))
 
 
-@overload_method(SeriesType, 'sub')
+@sdc_overload_method(SeriesType, 'sub')
 def hpat_pandas_series_sub(self, other, level=None, fill_value=None, axis=0):
     """
     Pandas Series method :meth:`pandas.Series.sub` implementation.
@@ -1588,7 +1588,7 @@ def hpat_pandas_series_sub(self, other, level=None, fill_value=None, axis=0):
     raise TypingError('{} The object must be a pandas.series or scalar. Given other: {}'.format(_func_name, other))
 
 
-@overload_method(SeriesType, 'sum')
+@sdc_overload_method(SeriesType, 'sum')
 def hpat_pandas_series_sum(
     self,
     axis=None,
@@ -1673,7 +1673,7 @@ def hpat_pandas_series_sum(
     return hpat_pandas_series_sum_impl
 
 
-@overload_method(SeriesType, 'take')
+@sdc_overload_method(SeriesType, 'take')
 def hpat_pandas_series_take(self, indices, axis=0, is_copy=False):
     """
     Pandas Series method :meth:`pandas.Series.take` implementation.
@@ -1733,7 +1733,7 @@ def hpat_pandas_series_take(self, indices, axis=0, is_copy=False):
     return hpat_pandas_series_take_impl
 
 
-@overload_method(SeriesType, 'idxmax')
+@sdc_overload_method(SeriesType, 'idxmax')
 def hpat_pandas_series_idxmax(self, axis=None, skipna=True, *args):
     """
     Pandas Series method :meth:`pandas.Series.idxmax` implementation.
@@ -1791,7 +1791,7 @@ def hpat_pandas_series_idxmax(self, axis=None, skipna=True, *args):
         return hpat_pandas_series_idxmax_index_impl
 
 
-@overload_method(SeriesType, 'mul')
+@sdc_overload_method(SeriesType, 'mul')
 def hpat_pandas_series_mul(self, other, level=None, fill_value=None, axis=0):
     """
     Pandas Series method :meth:`pandas.Series.mul` implementation.
@@ -1851,8 +1851,8 @@ def hpat_pandas_series_mul(self, other, level=None, fill_value=None, axis=0):
     raise TypingError('{} The object must be a pandas.series or scalar. Given other: {}'.format(_func_name, other))
 
 
-@overload_method(SeriesType, 'div')
-@overload_method(SeriesType, 'truediv')
+@sdc_overload_method(SeriesType, 'div')
+@sdc_overload_method(SeriesType, 'truediv')
 def hpat_pandas_series_div(self, other, level=None, fill_value=None, axis=0):
     """
     Pandas Series method :meth:`pandas.Series.div` and :meth:`pandas.Series.truediv` implementation.
@@ -1912,7 +1912,7 @@ def hpat_pandas_series_div(self, other, level=None, fill_value=None, axis=0):
     raise TypingError('{} The object must be a pandas.series or scalar. Given other: {}'.format(_func_name, other))
 
 
-@overload_method(SeriesType, 'floordiv')
+@sdc_overload_method(SeriesType, 'floordiv')
 def hpat_pandas_series_floordiv(self, other, level=None, fill_value=None, axis=0):
     """
     Pandas Series method :meth:`pandas.Series.floordiv` implementation.
@@ -1972,7 +1972,7 @@ def hpat_pandas_series_floordiv(self, other, level=None, fill_value=None, axis=0
     raise TypingError('{} The object must be a pandas.series or scalar. Given other: {}'.format(_func_name, other))
 
 
-@overload_method(SeriesType, 'pow')
+@sdc_overload_method(SeriesType, 'pow')
 def hpat_pandas_series_pow(self, other, level=None, fill_value=None, axis=0):
     """
     Pandas Series method :meth:`pandas.Series.pow` implementation.
@@ -2032,7 +2032,7 @@ def hpat_pandas_series_pow(self, other, level=None, fill_value=None, axis=0):
             _func_name, self, other))
 
 
-@overload_method(SeriesType, 'prod')
+@sdc_overload_method(SeriesType, 'prod')
 def hpat_pandas_series_prod(self, axis=None, skipna=True, level=None, numeric_only=None, min_count=0):
     """
     Pandas Series method :meth:`pandas.Series.prod` implementation.
@@ -2097,7 +2097,7 @@ def hpat_pandas_series_prod(self, axis=None, skipna=True, level=None, numeric_on
     return hpat_pandas_series_prod_impl
 
 
-@overload_method(SeriesType, 'quantile')
+@sdc_overload_method(SeriesType, 'quantile')
 def hpat_pandas_series_quantile(self, q=0.5, interpolation='linear'):
     """
     Pandas Series method :meth:`pandas.Series.quantile` implementation.
@@ -2132,7 +2132,7 @@ def hpat_pandas_series_quantile(self, q=0.5, interpolation='linear'):
     return hpat_pandas_series_quantile_impl
 
 
-@overload_method(SeriesType, 'rename')
+@sdc_overload_method(SeriesType, 'rename')
 def hpat_pandas_series_rename(self, index=None, copy=True, inplace=False, level=None):
     """
     Pandas Series method :meth:`pandas.Series.rename` implementation.
@@ -2203,7 +2203,7 @@ def hpat_pandas_series_rename(self, index=None, copy=True, inplace=False, level=
     return hpat_pandas_series_rename_idx_impl
 
 
-@overload_method(SeriesType, 'min')
+@sdc_overload_method(SeriesType, 'min')
 def hpat_pandas_series_min(self, axis=None, skipna=True, level=None, numeric_only=None):
     """
     Pandas Series method :meth:`pandas.Series.min` implementation.
@@ -2256,7 +2256,7 @@ def hpat_pandas_series_min(self, axis=None, skipna=True, level=None, numeric_onl
     return hpat_pandas_series_min_impl
 
 
-@overload_method(SeriesType, 'max')
+@sdc_overload_method(SeriesType, 'max')
 def hpat_pandas_series_max(self, axis=None, skipna=True, level=None, numeric_only=None):
     """
     Pandas Series method :meth:`pandas.Series.max` implementation.
@@ -2309,7 +2309,7 @@ def hpat_pandas_series_max(self, axis=None, skipna=True, level=None, numeric_onl
     return hpat_pandas_series_max_impl
 
 
-@overload_method(SeriesType, 'mean')
+@sdc_overload_method(SeriesType, 'mean')
 def hpat_pandas_series_mean(self, axis=None, skipna=None, level=None, numeric_only=None):
     """
     Pandas Series method :meth:`pandas.Series.mean` implementation.
@@ -2372,7 +2372,7 @@ def hpat_pandas_series_mean(self, axis=None, skipna=None, level=None, numeric_on
     return hpat_pandas_series_mean_impl
 
 
-@overload_method(SeriesType, 'mod')
+@sdc_overload_method(SeriesType, 'mod')
 def hpat_pandas_series_mod(self, other, level=None, fill_value=None, axis=0):
     """
     Pandas Series method :meth:`pandas.Series.mod` implementation.
@@ -2432,7 +2432,7 @@ def hpat_pandas_series_mod(self, other, level=None, fill_value=None, axis=0):
             _func_name, self, other))
 
 
-@overload_method(SeriesType, 'eq')
+@sdc_overload_method(SeriesType, 'eq')
 def hpat_pandas_series_eq(self, other, level=None, fill_value=None, axis=0):
     """
     Pandas Series method :meth:`pandas.Series.eq` implementation.
@@ -2492,7 +2492,7 @@ def hpat_pandas_series_eq(self, other, level=None, fill_value=None, axis=0):
             _func_name, self, other))
 
 
-@overload_method(SeriesType, 'ge')
+@sdc_overload_method(SeriesType, 'ge')
 def hpat_pandas_series_ge(self, other, level=None, fill_value=None, axis=0):
     """
     Pandas Series method :meth:`pandas.Series.ge` implementation.
@@ -2552,7 +2552,7 @@ def hpat_pandas_series_ge(self, other, level=None, fill_value=None, axis=0):
             _func_name, self, other))
 
 
-@overload_method(SeriesType, 'idxmin')
+@sdc_overload_method(SeriesType, 'idxmin')
 def hpat_pandas_series_idxmin(self, axis=None, skipna=True, *args):
     """
     Pandas Series method :meth:`pandas.Series.idxmin` implementation.
@@ -2616,7 +2616,7 @@ def hpat_pandas_series_idxmin(self, axis=None, skipna=True, *args):
         return hpat_pandas_series_idxmin_index_impl
 
 
-@overload_method(SeriesType, 'lt')
+@sdc_overload_method(SeriesType, 'lt')
 def hpat_pandas_series_lt(self, other, level=None, fill_value=None, axis=0):
     """
     Pandas Series method :meth:`pandas.Series.lt` implementation.
@@ -2676,7 +2676,7 @@ def hpat_pandas_series_lt(self, other, level=None, fill_value=None, axis=0):
             _func_name, self, other))
 
 
-@overload_method(SeriesType, 'gt')
+@sdc_overload_method(SeriesType, 'gt')
 def hpat_pandas_series_gt(self, other, level=None, fill_value=None, axis=0):
     """
     Pandas Series method :meth:`pandas.Series.gt` implementation.
@@ -2736,7 +2736,7 @@ def hpat_pandas_series_gt(self, other, level=None, fill_value=None, axis=0):
             _func_name, self, other))
 
 
-@overload_method(SeriesType, 'le')
+@sdc_overload_method(SeriesType, 'le')
 def hpat_pandas_series_le(self, other, level=None, fill_value=None, axis=0):
     """
     Pandas Series method :meth:`pandas.Series.le` implementation.
@@ -2796,7 +2796,7 @@ def hpat_pandas_series_le(self, other, level=None, fill_value=None, axis=0):
             _func_name, self, other))
 
 
-@overload_method(SeriesType, 'abs')
+@sdc_overload_method(SeriesType, 'abs')
 def hpat_pandas_series_abs(self):
     """
     Pandas Series method :meth:`pandas.Series.abs` implementation.
@@ -2829,7 +2829,7 @@ def hpat_pandas_series_abs(self):
     return hpat_pandas_series_abs_impl
 
 
-@overload_method(SeriesType, 'unique')
+@sdc_overload_method(SeriesType, 'unique')
 def hpat_pandas_series_unique(self):
     """
     Pandas Series method :meth:`pandas.Series.unique` implementation.
@@ -2878,7 +2878,7 @@ def hpat_pandas_series_unique(self):
     return hpat_pandas_series_unique_impl
 
 
-@overload_method(SeriesType, 'cumsum')
+@sdc_overload_method(SeriesType, 'cumsum')
 def hpat_pandas_series_cumsum(self, axis=None, skipna=True, *args):
     """
     Pandas Series method :meth:`pandas.Series.cumsum` implementation.
@@ -2934,7 +2934,7 @@ def hpat_pandas_series_cumsum(self, axis=None, skipna=True, *args):
     return hpat_pandas_series_cumsum_impl
 
 
-@overload_method(SeriesType, 'nunique')
+@sdc_overload_method(SeriesType, 'nunique')
 def hpat_pandas_series_nunique(self, dropna=True):
     """
     Pandas Series method :meth:`pandas.Series.nunique` implementation.
@@ -2992,7 +2992,7 @@ def hpat_pandas_series_nunique(self, dropna=True):
     return hpat_pandas_series_nunique_impl
 
 
-@overload_method(SeriesType, 'count')
+@sdc_overload_method(SeriesType, 'count')
 def hpat_pandas_series_count(self, level=None):
     """
     Pandas Series method :meth:`pandas.Series.count` implementation.
@@ -3041,7 +3041,7 @@ def hpat_pandas_series_count(self, level=None):
     return hpat_pandas_series_count_impl
 
 
-@overload_method(SeriesType, 'median')
+@sdc_overload_method(SeriesType, 'median')
 def hpat_pandas_series_median(self, axis=None, skipna=True, level=None, numeric_only=None):
     """
     Pandas Series method :meth:`pandas.Series.median` implementation.
@@ -3109,7 +3109,7 @@ def hpat_pandas_series_median(self, axis=None, skipna=True, level=None, numeric_
     return hpat_pandas_series_median_impl
 
 
-@overload_method(SeriesType, 'argsort')
+@sdc_overload_method(SeriesType, 'argsort')
 def hpat_pandas_series_argsort(self, axis=0, kind='quicksort', order=None):
     """
     Pandas Series method :meth:`pandas.Series.argsort` implementation.
@@ -3214,7 +3214,7 @@ def hpat_pandas_series_argsort(self, axis=0, kind='quicksort', order=None):
     return hpat_pandas_series_argsort_noidx_impl
 
 
-@overload_method(SeriesType, 'sort_values')
+@sdc_overload_method(SeriesType, 'sort_values')
 def hpat_pandas_series_sort_values(self, axis=0, ascending=True, inplace=False, kind='quicksort', na_position='last'):
     """
     Pandas Series method :meth:`pandas.Series.sort_values` implementation.
@@ -3390,7 +3390,7 @@ def hpat_pandas_series_sort_values(self, axis=0, ascending=True, inplace=False, 
         return hpat_pandas_series_sort_values_num_idx_impl
 
 
-@overload_method(SeriesType, 'dropna')
+@sdc_overload_method(SeriesType, 'dropna')
 def hpat_pandas_series_dropna(self, axis=0, inplace=False):
     """
     Pandas Series method :meth:`pandas.Series.dropna` implementation.
@@ -3434,7 +3434,7 @@ def hpat_pandas_series_dropna(self, axis=0, inplace=False):
     return hpat_pandas_series_dropna_impl
 
 
-@overload_method(SeriesType, 'fillna')
+@sdc_overload_method(SeriesType, 'fillna')
 def hpat_pandas_series_fillna(self, value=None, method=None, axis=None, inplace=False, limit=None, downcast=None):
     """
     Pandas Series method :meth:`pandas.Series.fillna` implementation.
@@ -3554,7 +3554,7 @@ def hpat_pandas_series_fillna(self, value=None, method=None, axis=None, inplace=
             return hpat_pandas_series_fillna_impl
 
 
-@overload_method(SeriesType, 'cov')
+@sdc_overload_method(SeriesType, 'cov')
 def hpat_pandas_series_cov(self, other, min_periods=None):
     """
     Pandas Series method :meth:`pandas.Series.cov` implementation.
@@ -3625,7 +3625,7 @@ def hpat_pandas_series_cov(self, other, min_periods=None):
     return hpat_pandas_series_cov_impl
 
 
-@overload_method(SeriesType, 'pct_change')
+@sdc_overload_method(SeriesType, 'pct_change')
 def hpat_pandas_series_pct_change(self, periods=1, fill_method='pad', limit=None, freq=None):
     """
     Pandas Series method :meth:`pandas.Series.pct_change` implementation.

--- a/sdc/datatypes/hpat_pandas_seriesgroupby_functions.py
+++ b/sdc/datatypes/hpat_pandas_seriesgroupby_functions.py
@@ -40,9 +40,10 @@ from numba.extending import overload_method
 from numba.errors import TypingError
 
 from sdc.datatypes.hpat_pandas_seriesgroupby_types import SeriesGroupByType
+from sdc.utils import sdc_overload_method
 
 
-@overload_method(SeriesGroupByType, 'count')
+@sdc_overload_method(SeriesGroupByType, 'count')
 def hpat_pandas_seriesgroupby_count(self):
     """
     Pandas Series method :meth:`pandas.core.groupby.GroupBy.count` implementation.

--- a/sdc/datatypes/hpat_pandas_seriesgroupby_types.py
+++ b/sdc/datatypes/hpat_pandas_seriesgroupby_types.py
@@ -38,6 +38,7 @@ from numba import types, cgutils
 from numba.extending import (models, overload, register_model, make_attribute_wrapper, intrinsic)
 from numba.datamodel import (register_default, StructModel)
 from numba.typing.templates import signature
+from sdc.utils import sdc_overload
 
 
 class SeriesGroupByTypeIterator(types.SimpleIteratorType):
@@ -145,7 +146,7 @@ def _hpat_pandas_seriesgroupby_init(typingctx, data):
     return sig, _hpat_pandas_seriesgroupby_init_codegen
 
 
-@overload(pandas.core.groupby.SeriesGroupBy)
+@sdc_overload(pandas.core.groupby.SeriesGroupBy)
 def hpat_pandas_seriesgroupby(
         obj,
         keys=None,

--- a/sdc/datatypes/hpat_pandas_stringmethods_functions.py
+++ b/sdc/datatypes/hpat_pandas_stringmethods_functions.py
@@ -418,7 +418,7 @@ def hpat_pandas_stringmethods_len(self):
     return hpat_pandas_stringmethods_len_impl
 
 
-@overload_method(StringMethodsType, 'ljust')
+@sdc_overload_method(StringMethodsType, 'ljust')
 def hpat_pandas_stringmethods_ljust(self, width, fillchar=' '):
     """
     Intel Scalable Dataframe Compiler User Guide
@@ -490,7 +490,7 @@ def hpat_pandas_stringmethods_ljust(self, width, fillchar=' '):
     return hpat_pandas_stringmethods_ljust_impl
 
 
-@overload_method(StringMethodsType, 'rjust')
+@sdc_overload_method(StringMethodsType, 'rjust')
 def hpat_pandas_stringmethods_rjust(self, width, fillchar=' '):
     """
     Intel Scalable Dataframe Compiler User Guide
@@ -562,7 +562,7 @@ def hpat_pandas_stringmethods_rjust(self, width, fillchar=' '):
     return hpat_pandas_stringmethods_rjust_impl
 
 
-@overload_method(StringMethodsType, 'startswith')
+@sdc_overload_method(StringMethodsType, 'startswith')
 def hpat_pandas_stringmethods_startswith(self, pat, na=None):
     """
     Pandas Series method :meth:`pandas.core.strings.StringMethods.startswith()` implementation.

--- a/sdc/datatypes/hpat_pandas_stringmethods_functions.py
+++ b/sdc/datatypes/hpat_pandas_stringmethods_functions.py
@@ -38,7 +38,7 @@
     `hpat_pandas_stringmethods_upper_parallel_impl` is paralell version
     (required additional import mentioned in the body)
 
-    @overload_method(StringMethodsType, 'upper')
+    @sdc_overload_method(StringMethodsType, 'upper')
     def hpat_pandas_stringmethods_upper(self):
 
         ty_checker = TypeChecker('Method stringmethods.upper().')
@@ -87,7 +87,7 @@ from numba.types import (Boolean, Integer, NoneType,
 
 from sdc.datatypes.common_functions import TypeChecker
 from sdc.datatypes.hpat_pandas_stringmethods_types import StringMethodsType
-
+from sdc.utils import sdc_overload_method
 
 _hpat_pandas_stringmethods_autogen_global_dict = {
     'pandas': pandas,
@@ -138,7 +138,7 @@ _hpat_pandas_stringmethods_functions_params = {
 }
 
 _hpat_pandas_stringmethods_functions_template = """
-# @overload_method(StringMethodsType, '{methodname}')
+# @sdc_overload_method(StringMethodsType, '{methodname}')
 def hpat_pandas_stringmethods_{methodname}(self{methodparams}):
     \"\"\"
     Pandas Series method :meth:`pandas.core.strings.StringMethods.{methodname}()` implementation.
@@ -189,7 +189,7 @@ def hpat_pandas_stringmethods_{methodname}(self{methodparams}):
 """
 
 
-@overload_method(StringMethodsType, 'center')
+@sdc_overload_method(StringMethodsType, 'center')
 def hpat_pandas_stringmethods_center(self, width, fillchar=' '):
     """
     Pandas Series method :meth:`pandas.core.strings.StringMethods.center()` implementation.
@@ -236,7 +236,7 @@ def hpat_pandas_stringmethods_center(self, width, fillchar=' '):
     return hpat_pandas_stringmethods_center_impl
 
 
-@overload_method(StringMethodsType, 'endswith')
+@sdc_overload_method(StringMethodsType, 'endswith')
 def hpat_pandas_stringmethods_endswith(self, pat, na=None):
     """
     Pandas Series method :meth:`pandas.core.strings.StringMethods.endswith()` implementation.
@@ -287,7 +287,7 @@ def hpat_pandas_stringmethods_endswith(self, pat, na=None):
     return hpat_pandas_stringmethods_endswith_impl
 
 
-@overload_method(StringMethodsType, 'find')
+@sdc_overload_method(StringMethodsType, 'find')
 def hpat_pandas_stringmethods_find(self, sub, start=0, end=None):
     """
     Pandas Series method :meth:`pandas.core.strings.StringMethods.find()` implementation.
@@ -346,7 +346,7 @@ def hpat_pandas_stringmethods_find(self, sub, start=0, end=None):
     return hpat_pandas_stringmethods_find_impl
 
 
-@overload_method(StringMethodsType, 'isupper')
+@sdc_overload_method(StringMethodsType, 'isupper')
 def hpat_pandas_stringmethods_isupper(self):
     """
     Pandas Series method :meth:`pandas.core.strings.StringMethods.isupper()` implementation.
@@ -382,7 +382,7 @@ def hpat_pandas_stringmethods_isupper(self):
     return hpat_pandas_stringmethods_isupper_impl
 
 
-@overload_method(StringMethodsType, 'len')
+@sdc_overload_method(StringMethodsType, 'len')
 def hpat_pandas_stringmethods_len(self):
     """
     Pandas Series method :meth:`pandas.core.strings.StringMethods.len()` implementation.

--- a/sdc/utils.py
+++ b/sdc/utils.py
@@ -44,6 +44,7 @@ from sdc.str_ext import string_type, list_string_array_type
 from sdc.str_arr_ext import string_array_type, num_total_chars, pre_alloc_string_array
 from enum import Enum
 import types as pytypes
+from numba.extending import overload_method
 
 
 # int values for types to pass to C code
@@ -562,3 +563,7 @@ def debug_prints():
 def update_globals(func, glbls):
     if isinstance(func, pytypes.FunctionType):
         func.__globals__.update(glbls)
+
+
+def sdc_overload_method(typ, name):
+    return overload_method(typ, name)

--- a/sdc/utils.py
+++ b/sdc/utils.py
@@ -44,7 +44,7 @@ from sdc.str_ext import string_type, list_string_array_type
 from sdc.str_arr_ext import string_array_type, num_total_chars, pre_alloc_string_array
 from enum import Enum
 import types as pytypes
-from numba.extending import overload, overload_method
+from numba.extending import overload, overload_method, overload_attribute
 
 
 # int values for types to pass to C code
@@ -571,3 +571,6 @@ def sdc_overload(func):
 
 def sdc_overload_method(typ, name):
     return overload_method(typ, name)
+
+def sdc_overload_attribute(typ, name):
+    return overload_attribute(typ, name)

--- a/sdc/utils.py
+++ b/sdc/utils.py
@@ -44,7 +44,7 @@ from sdc.str_ext import string_type, list_string_array_type
 from sdc.str_arr_ext import string_array_type, num_total_chars, pre_alloc_string_array
 from enum import Enum
 import types as pytypes
-from numba.extending import overload_method
+from numba.extending import overload, overload_method
 
 
 # int values for types to pass to C code
@@ -563,6 +563,10 @@ def debug_prints():
 def update_globals(func, glbls):
     if isinstance(func, pytypes.FunctionType):
         func.__globals__.update(glbls)
+
+
+def sdc_overload(func):
+    return overload(func)
 
 
 def sdc_overload_method(typ, name):

--- a/sdc/utils.py
+++ b/sdc/utils.py
@@ -572,5 +572,6 @@ def sdc_overload(func):
 def sdc_overload_method(typ, name):
     return overload_method(typ, name)
 
+
 def sdc_overload_attribute(typ, name):
     return overload_attribute(typ, name)


### PR DESCRIPTION
We will need to add `inline='always'` (and possible other attributes) to all our `@overload_method`s after numba `@overload_method` refactoring merge. Add our own attribute wrapper so it can be made from one place.