### PR TITLE
Fix benchmark results collecting

### DIFF
--- a/sdc/tests/tests_perf/test_perf_base.py
+++ b/sdc/tests/tests_perf/test_perf_base.py
@@ -6,19 +6,26 @@ from sdc.tests.tests_perf.test_perf_utils import *
 
 class TestBase(unittest.TestCase):
     iter_number = 5
+    test_results_class = TestResults
 
     @classmethod
-    def setUpClass(cls):
+    def create_test_results(cls):
         drivers = []
         if is_true(os.environ.get('SDC_TEST_PERF_EXCEL', True)):
             drivers.append(ExcelResultsDriver('perf_results.xlsx'))
         if is_true(os.environ.get('SDC_TEST_PERF_CSV', False)):
             drivers.append(CSVResultsDriver('perf_results.csv'))
 
-        cls.test_results = TestResults(drivers)
+        results = cls.test_results_class(drivers)
 
         if is_true(os.environ.get('LOAD_PREV_RESULTS')):
-            cls.test_results.load()
+            results.load()
+
+        return results
+
+    @classmethod
+    def setUpClass(cls):
+        cls.test_results = cls.create_test_results()
 
         cls.total_data_length = []
         cls.num_threads = int(os.environ.get('NUMBA_NUM_THREADS', config.NUMBA_NUM_THREADS))

--- a/sdc/tests/tests_perf/test_perf_series_str.py
+++ b/sdc/tests/tests_perf/test_perf_series_str.py
@@ -34,6 +34,7 @@ from contextlib import contextmanager
 import pandas as pd
 
 from sdc.tests.test_utils import *
+from sdc.tests.tests_perf.test_perf_base import TestBase
 from sdc.tests.tests_perf.test_perf_utils import *
 
 
@@ -109,24 +110,18 @@ def usecase_series_strip(input_data):
     return finish_time - start_time, res
 
 
-class TestSeriesStringMethods(unittest.TestCase):
+class TestSeriesStringMethods(TestBase):
     iter_number = 5
+    test_results_class = TestResultsStr
 
     @classmethod
     def setUpClass(cls):
-        cls.test_results = TestResultsStr()
-        if is_true(os.environ.get('LOAD_PREV_RESULTS')):
-            cls.test_results.load()
+        super().setUpClass()
 
         cls.total_data_length = [10**4, 10**5]
         cls.width = [16, 64, 512, 1024]
         cls.num_threads = int(os.environ.get('NUMBA_NUM_THREADS', config.NUMBA_NUM_THREADS))
         cls.threading_layer = os.environ.get('NUMBA_THREADING_LAYER', config.THREADING_LAYER)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.test_results.print()
-        cls.test_results.dump()
 
     def _test_series_str(self, pyfunc, name, input_data=None):
         input_data = input_data or test_global_input_data_unicode_kind4

--- a/sdc/tests/tests_perf/test_perf_unicode.py
+++ b/sdc/tests/tests_perf/test_perf_unicode.py
@@ -31,6 +31,7 @@ import time
 import numba
 
 from sdc.tests.test_utils import *
+from sdc.tests.tests_perf.test_perf_base import TestBase
 from sdc.tests.tests_perf.test_perf_utils import *
 
 
@@ -92,19 +93,15 @@ def usecase_center(input_data):
     return iter_time
 
 
-class TestStringMethods(unittest.TestCase):
+class TestStringMethods(TestBase):
+    test_results_class = TestResultsStr
+
     @classmethod
     def setUpClass(cls):
-        cls.test_results = TestResultsStr()
-        if is_true(os.environ.get('LOAD_PREV_RESULTS')):
-            cls.test_results.load()
+        super().setUpClass()
 
-        cls.total_data_size_bytes = [1.0E+07]
+        cls.total_data_size_bytes = [1.0E+04]
         cls.width = [16, 64, 512, 1024]
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.test_results.print()
 
     def _test_unicode(self, pyfunc, name):
         hpat_func = numba.njit(pyfunc)

--- a/sdc/tests/tests_perf/test_perf_utils.py
+++ b/sdc/tests/tests_perf/test_perf_utils.py
@@ -347,7 +347,7 @@ class TestResults:
         """
         for d in self.drivers:
             test_results_data = d.load(self.logger)
-            if test_results_data:
+            if test_results_data is not None:
                 self.test_results_data = test_results_data
                 break
 


### PR DESCRIPTION
This PR also closes #393.
This PR make TestBase as base class for all performance tests classes. It enables result collection for all classes.