### PR TITLE
Setup.py for docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -121,7 +121,7 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 html_sidebars = {
    '**': ['globaltoc.html', 'sourcelink.html', 'searchbox.html', 'relations.html'],

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8 -*-
 # *****************************************************************************
 # Copyright (c) 2019, Intel Corporation All rights reserved.
 #
@@ -28,8 +28,8 @@
 from setuptools import setup, Extension, find_packages, Command
 import platform
 import os
-from sphinx.setup_command import BuildDoc
 import sys
+from docs.source.buildscripts.sdc_build_doc import SDCBuildDoc
 
 
 # Note we don't import Numpy at the toplevel, since setup.py
@@ -47,48 +47,6 @@ SDC_NAME_STR = 'Intel® Scalable Dataframe Compiler'
 np_compile_args = np_misc.get_info('npymath')
 
 is_win = platform.system() == 'Windows'
-
-
-# Sphinx User's Documentation Build
-
-class BuildUserDoc(BuildDoc):
-
-    def __init__(self, dist):
-        # Remove current working directory from PYTHONPATH to avoid importing SDC from sources vs.
-        # from installed SDC package
-        cwd = os.getcwd()
-
-        removed_flag = True
-        while removed_flag:
-            removed_flag = False
-            if '' in sys.path:
-                sys.path.remove('')
-                removed_flag = True
-
-            if '.' in sys.path:
-                sys.path.remove('.')
-                removed_flag = True
-
-            if './' in sys.path:
-                sys.path.remove('./')
-                removed_flag = True
-
-            if cwd in sys.path:
-                sys.path.remove(cwd)
-                removed_flag = True
-
-        super(BuildUserDoc, self).__init__(dist)
-
-
-# Sphinx Developer's Documentation Build
-
-#class build_devdoc(build.build):
-#    description = "Build developer's documentation"
-#
-#    def run(self):
-#        spawn(['rm', '-rf', 'docs/_builddev'])
-#        spawn(['sphinx-build', '-b', 'html', '-d', 'docs/_builddev/docstrees',
-#               '-j1', 'docs/devsource', '-t', 'developer', 'docs/_builddev/html'])
 
 
 def readme():
@@ -414,7 +372,7 @@ class style(Command):
 # These commands extend standard setuptools build procedure
 #
 sdc_build_commands = versioneer.get_cmdclass()
-sdc_build_commands['build_user_doc'] = BuildUserDoc
+sdc_build_commands['build_doc'] = SDCBuildDoc
 sdc_build_commands.update({'style': style})
 sdc_version = versioneer.get_version()
 sdc_release = 'Alpha (' + versioneer.get_version() + ')'
@@ -445,11 +403,4 @@ setup(name=SDC_NAME_STR,
           "numba_extensions": [
               "init = sdc:_init_extension",
           ]},
-      # these are optional and override Sphinx conf.py settings
-      command_options={
-          'build_user_doc': {
-              'project': ('setup.py', SDC_NAME_STR),
-              'version': ('setup.py', sdc_version),
-              'release': ('setup.py', sdc_release),
-              'source_dir': ('setup.py', './docs/source')}},
       )

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # *****************************************************************************
 # Copyright (c) 2019, Intel Corporation All rights reserved.
 #
@@ -27,8 +28,8 @@
 from setuptools import setup, Extension, find_packages, Command
 import platform
 import os
-from distutils.command import build
-from distutils.spawn import spawn
+from sphinx.setup_command import BuildDoc
+import sys
 
 
 # Note we don't import Numpy at the toplevel, since setup.py
@@ -38,37 +39,56 @@ import numpy.distutils.misc_util as np_misc
 #import copy
 import versioneer
 
+# String constants for Intel SDC project configuration
+SDC_NAME_STR = 'Intel® Scalable Dataframe Compiler'
+
 # Inject required options for extensions compiled against the Numpy
 # C API (include dirs, library dirs etc.)
 np_compile_args = np_misc.get_info('npymath')
 
 is_win = platform.system() == 'Windows'
 
+
 # Sphinx User's Documentation Build
 
+class BuildUserDoc(BuildDoc):
 
-class build_doc(build.build):
-    description = "Build user's documentation"
+    def __init__(self, dist):
+        # Remove current working directory from PYTHONPATH to avoid importing SDC from sources vs.
+        # from installed SDC package
+        cwd = os.getcwd()
 
-    def run(self):
-        spawn(['rm', '-rf', 'docs/_build', 'API_doc', 'docs/usersource/api/'])
-        spawn(['python', 'docs/rename_function.py'])
-        spawn(['sphinx-build', '-b', 'html', '-d', 'docs/_build/docstrees',
-               '-j1', 'docs/usersource', '-t', 'user', 'docs/_build/html'])
-        spawn(['python', 'docs/CleanRSTfiles.py'])
-        spawn(['sphinx-build', '-b', 'html', '-d', 'docs/_build/docstrees',
-               '-j1', 'docs/usersource', '-t', 'user', 'docs/_build/html'])
+        removed_flag = True
+        while removed_flag:
+            removed_flag = False
+            if '' in sys.path:
+                sys.path.remove('')
+                removed_flag = True
+
+            if '.' in sys.path:
+                sys.path.remove('.')
+                removed_flag = True
+
+            if './' in sys.path:
+                sys.path.remove('./')
+                removed_flag = True
+
+            if cwd in sys.path:
+                sys.path.remove(cwd)
+                removed_flag = True
+
+        super(BuildUserDoc, self).__init__(dist)
+
 
 # Sphinx Developer's Documentation Build
 
-
-class build_devdoc(build.build):
-    description = "Build developer's documentation"
-
-    def run(self):
-        spawn(['rm', '-rf', 'docs/_builddev'])
-        spawn(['sphinx-build', '-b', 'html', '-d', 'docs/_builddev/docstrees',
-               '-j1', 'docs/devsource', '-t', 'developer', 'docs/_builddev/html'])
+#class build_devdoc(build.build):
+#    description = "Build developer's documentation"
+#
+#    def run(self):
+#        spawn(['rm', '-rf', 'docs/_builddev'])
+#        spawn(['sphinx-build', '-b', 'html', '-d', 'docs/_builddev/docstrees',
+#               '-j1', 'docs/devsource', '-t', 'developer', 'docs/_builddev/html'])
 
 
 def readme():
@@ -271,14 +291,6 @@ if _has_pyarrow:
 if _has_opencv:
     _ext_mods.append(ext_cv_wrapper)
 
-# Custom build commands
-#
-# These commands extends standart setuptools build procedure
-#
-sdc_build_commands = versioneer.get_cmdclass()
-sdc_build_commands['build_doc'] = build_doc
-sdc_build_commands['build_devdoc'] = build_devdoc
-
 
 class style(Command):
     """ Command to check and adjust code style
@@ -397,11 +409,19 @@ class style(Command):
             print("%s Style check passed" % self._result_marker)
 
 
+# Custom build commands
+#
+# These commands extend standard setuptools build procedure
+#
+sdc_build_commands = versioneer.get_cmdclass()
+sdc_build_commands['build_user_doc'] = BuildUserDoc
 sdc_build_commands.update({'style': style})
+sdc_version = versioneer.get_version()
+sdc_release = 'Alpha (' + versioneer.get_version() + ')'
 
-setup(name='sdc',
-      version=versioneer.get_version(),
-      description='compiling Python code for clusters',
+setup(name=SDC_NAME_STR,
+      version=sdc_version,
+      description='Numba* extension for compiling Pandas* operations',
       long_description=readme(),
       classifiers=[
           "Development Status :: 2 - Pre-Alpha",
@@ -412,9 +432,9 @@ setup(name='sdc',
           "Topic :: Software Development :: Compilers",
           "Topic :: System :: Distributed Computing",
       ],
-      keywords='data analytics cluster',
+      keywords='data analytics distributed Pandas Numba',
       url='https://github.com/IntelPython/sdc',
-      author='Intel',
+      author='Intel Corporation',
       packages=find_packages(),
       package_data={'sdc.tests': ['*.bz2'], },
       install_requires=['numba'],
@@ -424,6 +444,12 @@ setup(name='sdc',
       entry_points={
           "numba_extensions": [
               "init = sdc:_init_extension",
-          ],
-      },
-)
+          ]},
+      # these are optional and override Sphinx conf.py settings
+      command_options={
+          'build_user_doc': {
+              'project': ('setup.py', SDC_NAME_STR),
+              'version': ('setup.py', sdc_version),
+              'release': ('setup.py', sdc_release),
+              'source_dir': ('setup.py', './docs/source')}},
+      )


### PR DESCRIPTION
Tested locally:

1. Conda env with Sphinx installed on
>python setup.py build_doc - completed w/o warnings

2. Conda env without Sphinx
>python setup.py build_doc - failed with correct exception message

3. Conda env without Sphinx
>python setup.py install - completed