### PR TITLE
Enable tests in test_io.py and split TestIO to 3 classes

### DIFF
--- a/sdc/tests/test_io.py
+++ b/sdc/tests/test_io.py
@@ -76,8 +76,6 @@ class TestIO(TestCase):
 
 class TestParquet(TestIO):
 
-    @unittest.skip('Error - fix needed\n'
-                   'NUMA_PES=3 build')
     def test_pq_read(self):
         def test_impl():
             t = pq.read_table('kde.parquet')
@@ -102,8 +100,6 @@ class TestParquet(TestIO):
         self.assertEqual(count_array_REPs(), 0)
         self.assertEqual(count_parfor_REPs(), 0)
 
-    @unittest.skip('Error - fix needed\n'
-                   'NUMA_PES=3 build')
     def test_pq_read_freevar_str1(self):
         kde_file2 = 'kde.parquet'
 
@@ -117,8 +113,6 @@ class TestParquet(TestIO):
         self.assertEqual(count_array_REPs(), 0)
         self.assertEqual(count_parfor_REPs(), 0)
 
-    @unittest.skip('Error - fix needed\n'
-                   'NUMA_PES=3 build')
     def test_pd_read_parquet(self):
         def test_impl():
             df = pd.read_parquet('kde.parquet')
@@ -130,8 +124,6 @@ class TestParquet(TestIO):
         self.assertEqual(count_array_REPs(), 0)
         self.assertEqual(count_parfor_REPs(), 0)
 
-    @unittest.skip('Error - fix needed\n'
-                   'NUMA_PES=3 build')
     def test_pq_str(self):
         def test_impl():
             df = pq.read_table('example.parquet').to_pandas()
@@ -143,8 +135,6 @@ class TestParquet(TestIO):
         self.assertEqual(count_array_REPs(), 0)
         self.assertEqual(count_parfor_REPs(), 0)
 
-    @unittest.skip('Error - fix needed\n'
-                   'NUMA_PES=3 build')
     def test_pq_str_with_nan_seq(self):
         def test_impl():
             df = pq.read_table('example.parquet').to_pandas()
@@ -154,8 +144,6 @@ class TestParquet(TestIO):
         hpat_func = self.jit(test_impl)
         np.testing.assert_almost_equal(hpat_func(), test_impl())
 
-    @unittest.skip('Error - fix needed\n'
-                   'NUMA_PES=3 build')
     def test_pq_str_with_nan_par(self):
         def test_impl():
             df = pq.read_table('example.parquet').to_pandas()
@@ -179,8 +167,6 @@ class TestParquet(TestIO):
         self.assertEqual(count_array_REPs(), 0)
         self.assertEqual(count_parfor_REPs(), 0)
 
-    @unittest.skip('Error - fix needed\n'
-                   'NUMA_PES=3 build')
     def test_pq_bool(self):
         def test_impl():
             df = pq.read_table('example.parquet').to_pandas()
@@ -191,8 +177,6 @@ class TestParquet(TestIO):
         self.assertEqual(count_array_REPs(), 0)
         self.assertEqual(count_parfor_REPs(), 0)
 
-    @unittest.skip('Error - fix needed\n'
-                   'NUMA_PES=3 build')
     def test_pq_nan(self):
         def test_impl():
             df = pq.read_table('example.parquet').to_pandas()
@@ -203,8 +187,6 @@ class TestParquet(TestIO):
         self.assertEqual(count_array_REPs(), 0)
         self.assertEqual(count_parfor_REPs(), 0)
 
-    @unittest.skip('Error - fix needed\n'
-                   'NUMA_PES=3 build')
     def test_pq_float_no_nan(self):
         def test_impl():
             df = pq.read_table('example.parquet').to_pandas()

--- a/sdc/tests/test_io.py
+++ b/sdc/tests/test_io.py
@@ -37,7 +37,7 @@ from sdc.tests.test_base import TestCase
 from sdc.tests.test_utils import (count_array_REPs, count_parfor_REPs,
                                    count_parfor_OneDs, count_array_OneDs, dist_IR_contains, get_rank,
                                    get_start_end,
-                                   skip_numba_jit)
+                                   skip_numba_jit, skip_sdc_jit)
 from numba.config import IS_32BITS
 
 from sdc.io.csv_ext import pandas_read_csv as pd_read_csv
@@ -224,9 +224,9 @@ class TestParquet(TestIO):
         hpat_func = self.jit(test_impl)
         pd.testing.assert_frame_equal(hpat_func(), test_impl())
 
-    @unittest.skip('Error: Attribute "dtype" are different\n'
-                   '[left]:  datetime64[ns]\n'
-                   '[right]: object')
+    @skip_sdc_jit('Error: Attribute "dtype" are different\n'
+                  '[left]:  datetime64[ns]\n'
+                  '[right]: object')
     def test_pq_spark_date(self):
         def test_impl():
             df = pd.read_parquet('sdf_dt.pq')
@@ -766,8 +766,8 @@ class TestCSV(TestIO):
         hpat_func = self.jit(test_impl)
         pd.testing.assert_frame_equal(hpat_func(), test_impl())
 
-    @unittest.skip('TypeError: to_csv() takes from 1 to 20 positional arguments but 21 were given)\n'
-                   'Notice: Not seen with Pandas 0.24.2')
+    @skip_sdc_jit('TypeError: to_csv() takes from 1 to 20 positional arguments but 21 were given)\n'
+                  'Notice: Not seen with Pandas 0.24.2')
     def test_write_csv1(self):
         def test_impl(df, fname):
             df.to_csv(fname)
@@ -782,8 +782,8 @@ class TestCSV(TestIO):
         # TODO: delete files
         pd.testing.assert_frame_equal(pd.read_csv(hp_fname), pd.read_csv(pd_fname))
 
-    @unittest.skip('AttributeError: Failed in hpat mode pipeline (step: convert to distributed)\n'
-                   'module \'sdc.hio\' has no attribute \'file_write_parallel\'')
+    @skip_sdc_jit('AttributeError: Failed in hpat mode pipeline (step: convert to distributed)\n'
+                  'module \'sdc.hio\' has no attribute \'file_write_parallel\'')
     def test_write_csv_parallel1(self):
         def test_impl(n, fname):
             df = pd.DataFrame({'A': np.arange(n)})

--- a/sdc/tests/test_io.py
+++ b/sdc/tests/test_io.py
@@ -76,6 +76,7 @@ class TestIO(TestCase):
 
 class TestParquet(TestIO):
 
+    @skip_numba_jit
     def test_pq_read(self):
         def test_impl():
             t = pq.read_table('kde.parquet')
@@ -100,6 +101,7 @@ class TestParquet(TestIO):
         self.assertEqual(count_array_REPs(), 0)
         self.assertEqual(count_parfor_REPs(), 0)
 
+    @skip_numba_jit
     def test_pq_read_freevar_str1(self):
         kde_file2 = 'kde.parquet'
 
@@ -113,6 +115,7 @@ class TestParquet(TestIO):
         self.assertEqual(count_array_REPs(), 0)
         self.assertEqual(count_parfor_REPs(), 0)
 
+    @skip_numba_jit
     def test_pd_read_parquet(self):
         def test_impl():
             df = pd.read_parquet('kde.parquet')
@@ -124,6 +127,7 @@ class TestParquet(TestIO):
         self.assertEqual(count_array_REPs(), 0)
         self.assertEqual(count_parfor_REPs(), 0)
 
+    @skip_numba_jit
     def test_pq_str(self):
         def test_impl():
             df = pq.read_table('example.parquet').to_pandas()
@@ -135,6 +139,7 @@ class TestParquet(TestIO):
         self.assertEqual(count_array_REPs(), 0)
         self.assertEqual(count_parfor_REPs(), 0)
 
+    @skip_numba_jit
     def test_pq_str_with_nan_seq(self):
         def test_impl():
             df = pq.read_table('example.parquet').to_pandas()
@@ -144,6 +149,7 @@ class TestParquet(TestIO):
         hpat_func = self.jit(test_impl)
         np.testing.assert_almost_equal(hpat_func(), test_impl())
 
+    @skip_numba_jit
     def test_pq_str_with_nan_par(self):
         def test_impl():
             df = pq.read_table('example.parquet').to_pandas()
@@ -167,6 +173,7 @@ class TestParquet(TestIO):
         self.assertEqual(count_array_REPs(), 0)
         self.assertEqual(count_parfor_REPs(), 0)
 
+    @skip_numba_jit
     def test_pq_bool(self):
         def test_impl():
             df = pq.read_table('example.parquet').to_pandas()
@@ -177,6 +184,7 @@ class TestParquet(TestIO):
         self.assertEqual(count_array_REPs(), 0)
         self.assertEqual(count_parfor_REPs(), 0)
 
+    @skip_numba_jit
     def test_pq_nan(self):
         def test_impl():
             df = pq.read_table('example.parquet').to_pandas()
@@ -187,6 +195,7 @@ class TestParquet(TestIO):
         self.assertEqual(count_array_REPs(), 0)
         self.assertEqual(count_parfor_REPs(), 0)
 
+    @skip_numba_jit
     def test_pq_float_no_nan(self):
         def test_impl():
             df = pq.read_table('example.parquet').to_pandas()
@@ -209,6 +218,7 @@ class TestParquet(TestIO):
     @skip_sdc_jit('Error: Attribute "dtype" are different\n'
                   '[left]:  datetime64[ns]\n'
                   '[right]: object')
+    @skip_numba_jit
     def test_pq_spark_date(self):
         def test_impl():
             df = pd.read_parquet('sdf_dt.pq')
@@ -748,6 +758,7 @@ class TestCSV(TestIO):
         hpat_func = self.jit(test_impl)
         pd.testing.assert_frame_equal(hpat_func(), test_impl())
 
+    @skip_numba_jit
     @skip_sdc_jit('TypeError: to_csv() takes from 1 to 20 positional arguments but 21 were given)\n'
                   'Notice: Not seen with Pandas 0.24.2')
     def test_write_csv1(self):
@@ -764,6 +775,7 @@ class TestCSV(TestIO):
         # TODO: delete files
         pd.testing.assert_frame_equal(pd.read_csv(hp_fname), pd.read_csv(pd_fname))
 
+    @skip_numba_jit
     @skip_sdc_jit('AttributeError: Failed in hpat mode pipeline (step: convert to distributed)\n'
                   'module \'sdc.hio\' has no attribute \'file_write_parallel\'')
     def test_write_csv_parallel1(self):
@@ -821,6 +833,7 @@ class TestNumpy(TestIO):
             B = np.fromfile("np_file_3.dat", np.float64)
             np.testing.assert_almost_equal(A, B)
 
+    @skip_numba_jit("AssertionError: Failed in nopython mode pipeline (step: Preprocessing for parfors)")
     def test_np_io4(self):
         # parallel version
         def test_impl(n):

--- a/sdc/tests/test_io.py
+++ b/sdc/tests/test_io.py
@@ -73,6 +73,9 @@ class TestIO(TestCase):
             A = np.random.ranf(n)
             A.tofile("np_file1.dat")
 
+
+class TestParquet(TestIO):
+
     @unittest.skip('Error - fix needed\n'
                    'NUMA_PES=3 build')
     def test_pq_read(self):
@@ -231,6 +234,9 @@ class TestIO(TestCase):
 
         hpat_func = self.jit(test_impl)
         pd.testing.assert_frame_equal(hpat_func(), test_impl())
+
+
+class TestCSV(TestIO):
 
     def test_pyarrow(self):
         tests = [
@@ -795,6 +801,9 @@ class TestIO(TestCase):
         if get_rank() == 0:
             pd.testing.assert_frame_equal(
                 pd.read_csv(hp_fname), pd.read_csv(pd_fname))
+
+
+class TestNumpy(TestIO):
 
     @skip_numba_jit
     def test_np_io1(self):


### PR DESCRIPTION
This PR is part of #354 without check_jitted() function.
This PR splits TestIO to 3 classes for CSV, Parquet and NumPy. Also it enables some tests for sdc.jit and skip some for numba.jit.