### PR TITLE
Helps to see which skipped tests are passing now

### DIFF
--- a/sdc/tests/test_utils.py
+++ b/sdc/tests/test_utils.py
@@ -133,6 +133,7 @@ def skip_numba_jit(msg_or_func=None):
     msg, func = msg_and_func(msg_or_func)
     wrapper = unittest.skipUnless(sdc.config.config_pipeline_hpat_default, msg or "numba pipeline not supported")
     # wrapper = lambda f: f  # disable skipping
+    # wrapper = unittest.expectedFailure
     return wrapper(func) if func else wrapper
 
 
@@ -140,4 +141,5 @@ def skip_sdc_jit(msg_or_func=None):
     msg, func = msg_and_func(msg_or_func)
     wrapper = unittest.skipIf(sdc.config.config_pipeline_hpat_default, msg or "sdc pipeline not supported")
     # wrapper = lambda f: f  # disable skipping
+    # wrapper = unittest.expectedFailure
     return wrapper(func) if func else wrapper


### PR DESCRIPTION
Uncomment this lines to see which skipped tests are passing now.
You will see that skipped tests are now have status `expected failure` but some tests may became `unexpected success`.
You can unskip `unexpected success` tests because they are passing now.