### PR TITLE
Rename test_results_class to results_class in tests_perf

### DIFF
--- a/sdc/tests/tests_perf/test_perf_base.py
+++ b/sdc/tests/tests_perf/test_perf_base.py
@@ -6,7 +6,7 @@ from sdc.tests.tests_perf.test_perf_utils import *
 
 class TestBase(unittest.TestCase):
     iter_number = 5
-    test_results_class = TestResults
+    results_class = TestResults
 
     @classmethod
     def create_test_results(cls):
@@ -16,7 +16,7 @@ class TestBase(unittest.TestCase):
         if is_true(os.environ.get('SDC_TEST_PERF_CSV', False)):
             drivers.append(CSVResultsDriver('perf_results.csv'))
 
-        results = cls.test_results_class(drivers)
+        results = cls.results_class(drivers)
 
         if is_true(os.environ.get('LOAD_PREV_RESULTS')):
             results.load()

--- a/sdc/tests/tests_perf/test_perf_series_str.py
+++ b/sdc/tests/tests_perf/test_perf_series_str.py
@@ -112,7 +112,7 @@ def usecase_series_strip(input_data):
 
 class TestSeriesStringMethods(TestBase):
     iter_number = 5
-    test_results_class = TestResultsStr
+    results_class = TestResultsStr
 
     @classmethod
     def setUpClass(cls):

--- a/sdc/tests/tests_perf/test_perf_unicode.py
+++ b/sdc/tests/tests_perf/test_perf_unicode.py
@@ -94,7 +94,7 @@ def usecase_center(input_data):
 
 
 class TestStringMethods(TestBase):
-    test_results_class = TestResultsStr
+    results_class = TestResultsStr
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
test_results_class is attribute of TestBase and could be interpreted by Python UnitTest incorrectly.