### PR TITLE
Use examples results in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -166,11 +166,10 @@ Building documentation
 ----------------------
 Building Intel SDC User's Guide documentation requires pre-installed Intel SDC package along with compatible Pandas* version as well as Sphinx* 2.2.1 or later.
 
-You can install Sphinx* using either ``conda`` or ``pip``:
+Use ``pip`` to install Sphinx* and extensions:
 ::
 
-    conda install sphinx
-    pip install sphinx
+    pip install sphinx sphinxcontrib-programoutput
 
 Currently the build precedure is based on ``make`` located at ``./sdc/docs/`` folder. While it is not generally required we recommended that you clean up the system from previous documentaiton build by running
 ::

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -94,6 +94,7 @@ extensions = [
     'sphinx.ext.extlinks',
     'sphinx.ext.githubpages',
     'sphinx.ext.napoleon',
+    'sphinxcontrib.programoutput',
 ]
 
 

--- a/sdc/datatypes/hpat_pandas_series_functions.py
+++ b/sdc/datatypes/hpat_pandas_series_functions.py
@@ -73,10 +73,8 @@ def hpat_pandas_series_getitem(self, idx):
        :caption: Getting Pandas Series elements
        :name: ex_series_getitem
 
-    .. code-block:: console
-
-        > python ./series_getitem.py
-        55
+    .. command-output:: python ./series_getitem.py
+       :cwd: ../../../examples
 
     .. todo:: Fix SDC behavior and add the expected output of the > python ./series_getitem.py to the docstring
 
@@ -411,14 +409,8 @@ def hpat_pandas_series_value_counts(self, normalize=False, sort=True, ascending=
        :caption: Getting the number of values excluding NaNs
        :name: ex_series_value_counts
 
-    .. code-block:: console
-
-        > python ./series/series_value_counts.py
-        3.0    2
-        4.0    1
-        2.0    1
-        1.0    1
-        dtype: int64
+    .. command-output:: python ./series/series_value_counts.py
+       :cwd: ../../../examples
 
      .. note::
 
@@ -724,15 +716,8 @@ def hpat_pandas_series_rolling(self, window, min_periods=None, center=False,
        :caption: Calculate the rolling minimum.
        :name: ex_series_rolling
 
-    .. code-block:: console
-
-        > python ./series_rolling_min.py
-        0    NaN
-        1    NaN
-        2    3.0
-        3    2.0
-        4    2.0
-        dtype: float64
+    .. command-output:: python ./series/rolling/series_rolling_min.py
+       :cwd: ../../../examples
 
     .. todo:: Add support of parameters ``center``, ``win_type``, ``on``, ``axis`` and ``closed``
 
@@ -1752,13 +1737,8 @@ def hpat_pandas_series_add(self, other, level=None, fill_value=None, axis=0):
        :caption: Getting the addition of Series and other
        :name: ex_series_add
 
-    .. code-block:: console
-
-        > python ./series/series_add.py
-        0    5
-        1    7
-        2    9
-        dtype: int64
+    .. command-output:: python ./series/series_add.py
+       :cwd: ../../../examples
 
     .. note::
 
@@ -2119,13 +2099,8 @@ def hpat_pandas_series_mul(self, other, level=None, fill_value=None, axis=0):
        :caption: Element-wise multiplication of two Series
        :name: ex_series_mul
 
-    .. code-block:: console
-
-        > python ./series/series_mul.py
-        0      0
-        1      3
-        2    200
-        dtype: int64
+    .. command-output:: python ./series/series_mul.py
+       :cwd: ../../../examples
 
      .. note::
 
@@ -2218,13 +2193,8 @@ def hpat_pandas_series_div(self, other, level=None, fill_value=None, axis=0):
        :caption: Element-wise division of one Series by another (binary operator div)
        :name: ex_series_div
 
-    .. code-block:: console
-
-        > python ./series/series_div.py
-        0    0.25
-        1    0.50
-        2    0.25
-        dtype: float64
+    .. command-output:: python ./series/series_div.py
+       :cwd: ../../../examples
 
     .. note::
 
@@ -2318,13 +2288,8 @@ def hpat_pandas_series_truediv(self, other, level=None, fill_value=None, axis=0)
        :caption: Element-wise division of one Series by another (binary operator truediv)
        :name: ex_series_truediv
 
-    .. code-block:: console
-
-        > python ./series/series_truediv.py
-        0    0.25
-        1    0.50
-        2    0.25
-        dtype: float64
+    .. command-output:: python ./series/series_truediv.py
+       :cwd: ../../../examples
 
     .. note::
 
@@ -2623,10 +2588,8 @@ def hpat_pandas_series_quantile(self, q=0.5, interpolation='linear'):
        :caption: Computing quantile for the Series
        :name: ex_series_quantile
 
-    .. code-block:: console
-
-        > python ./series/series_quantile.py
-        2.5
+    .. command-output:: python ./series/series_quantile.py
+       :cwd: ../../../examples
 
     .. note::
 
@@ -2811,10 +2774,8 @@ def hpat_pandas_series_max(self, axis=None, skipna=True, level=None, numeric_onl
        :caption: Getting the maximum value of Series elements
        :name: ex_series_max
 
-    .. code-block:: console
-
-        > python ./series/series_max.py
-        4
+    .. command-output:: python ./series/series_max.py
+       :cwd: ../../../examples
 
     .. note::
 
@@ -3508,10 +3469,8 @@ def hpat_pandas_series_unique(self):
        :caption: Getting unique values in Series
        :name: ex_series_unique
 
-    .. code-block:: console
-
-        > python ./series/series_unique.py
-        array([2, 1, 3], dtype=int64)
+    .. command-output:: python ./series/series_unique.py
+       :cwd: ../../../examples
 
     Intel Scalable Dataframe Compiler Developer Guide
     *************************************************
@@ -3689,10 +3648,8 @@ def hpat_pandas_series_count(self, level=None):
        :caption: Counting non-NaN values in Series
        :name: ex_series_count
 
-    .. code-block:: console
-
-        > python ./series/series_count.py
-        2
+    .. command-output:: python ./series/series_count.py
+       :cwd: ../../../examples
 
     .. note::
 

--- a/sdc/datatypes/hpat_pandas_series_functions.py
+++ b/sdc/datatypes/hpat_pandas_series_functions.py
@@ -3452,13 +3452,8 @@ def hpat_pandas_series_abs(self):
        :caption: Getting the absolute value of each element in Series
        :name: ex_series_abs
 
-    .. code-block:: console
-
-        > python ./series/series_abs.py
-        0     1.10
-        1     2.00
-        2     3.33
-        dtype: float64
+    .. command-output:: python ./series/series_abs.py
+       :cwd: ../../../examples
 
     .. seealso::
 

--- a/sdc/datatypes/hpat_pandas_series_rolling_functions.py
+++ b/sdc/datatypes/hpat_pandas_series_rolling_functions.py
@@ -50,9 +50,8 @@ hpat_pandas_series_rolling_docstring_tmpl = """
        :caption: {example_caption}
        :name: ex_series_rolling_{method_name}
 
-    .. code-block:: console
-
-        > python ./series_rolling_{method_name}.py{example_result}
+    .. command-output:: python ./series/rolling/series_rolling_{method_name}.py
+       :cwd: ../../../examples
 
     .. seealso::
         :ref:`Series.rolling <pandas.Series.rolling>`
@@ -328,15 +327,8 @@ def hpat_pandas_series_rolling_count(self):
        :caption: Count of any non-NaN observations inside the window.
        :name: ex_series_rolling_count
 
-    .. code-block:: console
-
-        > python ./series_rolling_count.py
-        0    1.0
-        1    2.0
-        2    3.0
-        3    2.0
-        4    2.0
-        dtype: float64
+    .. command-output:: python ./series/rolling/series_rolling_count.py
+       :cwd: ../../../examples
 
     .. seealso::
         :ref:`Series.rolling <pandas.Series.rolling>`
@@ -453,15 +445,8 @@ def hpat_pandas_series_rolling_max(self):
        :caption: Calculate the rolling maximum.
        :name: ex_series_rolling_max
 
-    .. code-block:: console
-
-        > python ./series_rolling_max.py
-        0    NaN
-        1    NaN
-        2    5.0
-        3    5.0
-        4    6.0
-        dtype: float64
+    .. command-output:: python ./series/rolling/series_rolling_max.py
+       :cwd: ../../../examples
 
     .. seealso::
         :ref:`Series.rolling <pandas.Series.rolling>`
@@ -532,15 +517,8 @@ def hpat_pandas_series_rolling_min(self):
        :caption: Calculate the rolling minimum.
        :name: ex_series_rolling_min
 
-    .. code-block:: console
-
-        > python ./series_rolling_min.py
-        0    NaN
-        1    NaN
-        2    3.0
-        3    2.0
-        4    2.0
-        dtype: float64
+    .. command-output:: python ./series/rolling/series_rolling_min.py
+       :cwd: ../../../examples
 
     .. seealso::
         :ref:`Series.rolling <pandas.Series.rolling>`
@@ -645,15 +623,8 @@ def hpat_pandas_series_rolling_sum(self):
        :caption: Calculate rolling sum of given Series.
        :name: ex_series_rolling_sum
 
-    .. code-block:: console
-
-        > python ./series_rolling_sum.py
-        0     NaN
-        1     NaN
-        2    12.0
-        3    10.0
-        4    13.0
-        dtype: float64
+    .. command-output:: python ./series/rolling/series_rolling_sum.py
+       :cwd: ../../../examples
 
     .. seealso::
         :ref:`Series.rolling <pandas.Series.rolling>`
@@ -772,15 +743,6 @@ def hpat_pandas_series_rolling_var(self, ddof=1):
 hpat_pandas_series_rolling_corr.__doc__ = hpat_pandas_series_rolling_docstring_tmpl.format(**{
     'method_name': 'corr',
     'example_caption': 'Calculate rolling correlation.',
-    'example_result':
-    """
-        0         NaN
-        1         NaN
-        2         NaN
-        3    0.333333
-        4    0.916949
-        dtype: float64
-    """,
     'limitations_block':
     """
     Limitations
@@ -800,15 +762,6 @@ hpat_pandas_series_rolling_corr.__doc__ = hpat_pandas_series_rolling_docstring_t
 hpat_pandas_series_rolling_cov.__doc__ = hpat_pandas_series_rolling_docstring_tmpl.format(**{
     'method_name': 'cov',
     'example_caption': 'Calculate rolling covariance.',
-    'example_result':
-    """
-        0         NaN
-        1         NaN
-        2         NaN
-        3    0.166667
-        4    4.333333
-        dtype: float64
-    """,
     'limitations_block':
     """
     Limitations
@@ -830,15 +783,6 @@ hpat_pandas_series_rolling_cov.__doc__ = hpat_pandas_series_rolling_docstring_tm
 hpat_pandas_series_rolling_mean.__doc__ = hpat_pandas_series_rolling_docstring_tmpl.format(**{
     'method_name': 'mean',
     'example_caption': 'Calculate the rolling mean of the values.',
-    'example_result':
-    """
-        0         NaN
-        1         NaN
-        2    4.000000
-        3    3.333333
-        4    4.333333
-        dtype: float64
-    """,
     'limitations_block':
     """
     Limitations
@@ -851,15 +795,6 @@ hpat_pandas_series_rolling_mean.__doc__ = hpat_pandas_series_rolling_docstring_t
 hpat_pandas_series_rolling_median.__doc__ = hpat_pandas_series_rolling_docstring_tmpl.format(**{
     'method_name': 'median',
     'example_caption': 'Calculate the rolling median.',
-    'example_result':
-    """
-        0    NaN
-        1    NaN
-        2    4.0
-        3    3.0
-        4    5.0
-        dtype: float64
-    """,
     'limitations_block': '',
     'extra_params': ''
 })
@@ -867,15 +802,6 @@ hpat_pandas_series_rolling_median.__doc__ = hpat_pandas_series_rolling_docstring
 hpat_pandas_series_rolling_quantile.__doc__ = hpat_pandas_series_rolling_docstring_tmpl.format(**{
     'method_name': 'quantile',
     'example_caption': 'Calculate the rolling quantile.',
-    'example_result':
-    """
-        0    NaN
-        1    NaN
-        2    3.5
-        3    2.5
-        4    3.5
-        dtype: float64
-    """,
     'limitations_block':
     """
     Limitations
@@ -895,15 +821,6 @@ hpat_pandas_series_rolling_quantile.__doc__ = hpat_pandas_series_rolling_docstri
 hpat_pandas_series_rolling_std.__doc__ = hpat_pandas_series_rolling_docstring_tmpl.format(**{
     'method_name': 'std',
     'example_caption': 'Calculate rolling standard deviation.',
-    'example_result':
-    """
-        0         NaN
-        1         NaN
-        2    1.000000
-        3    1.527525
-        4    2.081666
-        dtype: float64
-    """,
     'limitations_block':
     """
     Limitations
@@ -920,15 +837,6 @@ hpat_pandas_series_rolling_std.__doc__ = hpat_pandas_series_rolling_docstring_tm
 hpat_pandas_series_rolling_var.__doc__ = hpat_pandas_series_rolling_docstring_tmpl.format(**{
     'method_name': 'var',
     'example_caption': 'Calculate unbiased rolling variance.',
-    'example_result':
-    """
-        0         NaN
-        1         NaN
-        2    1.000000
-        3    2.333333
-        4    4.333333
-        dtype: float64
-    """,
     'limitations_block':
     """
     Limitations

--- a/sdc/datatypes/hpat_pandas_stringmethods_functions.py
+++ b/sdc/datatypes/hpat_pandas_stringmethods_functions.py
@@ -208,13 +208,8 @@ def hpat_pandas_stringmethods_center(self, width, fillchar=' '):
        :caption: Filling left and right side of strings in the Series with an additional character
        :name: ex_series_str_center
 
-    .. code-block:: console
-
-        > python ./series/str/series_str_center.py
-        0    *dog*
-        1    *foo*
-        2    *bar*
-        dtype: object
+    .. command-output:: python ./series/str/series_str_center.py
+       :cwd: ../../../examples
 
     .. todo:: Add support of 32-bit Unicode for `str.center()`
 
@@ -284,13 +279,8 @@ def hpat_pandas_stringmethods_endswith(self, pat, na=None):
        :caption: Test if the end of each string element matches a string
        :name: ex_series_str_endswith
 
-    .. code-block:: console
-
-        > python ./series/str/series_str_endswith.py
-        0    False
-        1     True
-        2     True
-        dtype: bool
+    .. command-output:: python ./series/str/series_str_endswith.py
+       :cwd: ../../../examples
 
     .. todo::
         - Add support of matching the end of each string by a pattern
@@ -374,13 +364,8 @@ def hpat_pandas_stringmethods_find(self, sub, start=0, end=None):
        :caption: Return lowest indexes in each strings in the Series
        :name: ex_series_str_find
 
-    .. code-block:: console
-
-        > python ./series/str/series_str_find.py
-        0   -1
-        1    0
-        2    3
-        dtype: int64
+    .. command-output:: python ./series/str/series_str_find.py
+       :cwd: ../../../examples
 
     .. todo:: Add support of parameters ``start`` and ``end``
 
@@ -466,13 +451,8 @@ def hpat_pandas_stringmethods_isupper(self):
        :caption: Check whether all characters in each string are uppercase
        :name: ex_series_str_isupper
 
-    .. code-block:: console
-
-        > python ./series/str/series_str_isupper.py
-        0     True
-        1    False
-        2    False
-        dtype: bool
+    .. command-output:: python ./series/str/series_str_isupper.py
+       :cwd: ../../../examples
 
     .. seealso::
         :ref:`Series.str.isalpha <pandas.Series.str.isalpha>`
@@ -547,13 +527,8 @@ def hpat_pandas_stringmethods_len(self):
        :caption: Compute the length of each element in the Series
        :name: ex_series_str_len
 
-    .. code-block:: console
-
-        > python ./series/str/series_str_len.py
-        0    3
-        1    3
-        2    6
-        dtype: int64
+    .. command-output:: python ./series/str/series_str_len.py
+       :cwd: ../../../examples
 
     .. seealso::
         `str.len`
@@ -616,13 +591,8 @@ def hpat_pandas_stringmethods_ljust(self, width, fillchar=' '):
        :caption: Filling right side of strings in the Series with an additional character
        :name: ex_series_str_ljust
 
-    .. code-block:: console
-
-        > python ./series/str/series_str_ljust.py
-        0    dog**
-        1    foo**
-        2    bar**
-        dtype: object
+    .. command-output:: python ./series/str/series_str_ljust.py
+       :cwd: ../../../examples
 
     .. todo:: Add support of 32-bit Unicode for `str.ljust()`
 
@@ -692,13 +662,8 @@ def hpat_pandas_stringmethods_rjust(self, width, fillchar=' '):
        :caption: Filling left side of strings in the Series with an additional character
        :name: ex_series_str_rjust
 
-    .. code-block:: console
-
-        > python ./series/str/series_str_rjust.py
-        0    **dog
-        1    **foo
-        2    **bar
-        dtype: object
+    .. command-output:: python ./series/str/series_str_rjust.py
+       :cwd: ../../../examples
 
     .. todo:: Add support of 32-bit Unicode for `str.rjust()`
 
@@ -768,13 +733,8 @@ def hpat_pandas_stringmethods_startswith(self, pat, na=None):
        :caption: Test if the start of each string element matches a string
        :name: ex_series_str_startswith
 
-    .. code-block:: console
-
-        > python ./series/str/series_str_startswith.py
-        0     True
-        1    False
-        2     True
-        dtype: bool
+    .. command-output:: python ./series/str/series_str_startswith.py
+       :cwd: ../../../examples
 
     .. todo::
         - Add support of matching the start of each string by a pattern
@@ -858,13 +818,8 @@ def hpat_pandas_stringmethods_zfill(self, width):
        :caption: Pad strings in the Series by prepending '0' characters
        :name: ex_series_str_zfill
 
-    .. code-block:: console
-
-        > python ./series/str/series_str_zfill.py
-        0    00dog
-        1    00foo
-        2    00bar
-        dtype: object
+    .. command-output:: python ./series/str/series_str_zfill.py
+       :cwd: ../../../examples
 
     .. todo:: Add support of 32-bit Unicode for `str.zfill()`
 


### PR DESCRIPTION
This PR applies Sphinx extension [sphinxcontrib-programoutput](https://sphinxcontrib-programoutput.readthedocs.io/) and give example of modifying docstrings.
Instead of using this:
```python
    .. code-block:: console
        > python ./series/series_abs.py
```
Now it should be:
```python
    .. command-output:: python ./series/series_abs.py
       :cwd: ../../../examples
```

Note: For `:cwd:` use the same example folder you use in:
```python
    .. literalinclude:: ../../../examples/series/series_abs.py
```