### PR TITLE
Introduce config options which enables parallel/inline for overloads

### DIFF
--- a/sdc/config.py
+++ b/sdc/config.py
@@ -30,7 +30,6 @@ This is a set of configuration variables in SDC initialized at startup
 
 
 import os
-from distutils import util as distutils_util
 
 try:
     import pyarrow
@@ -47,7 +46,17 @@ else:
     _has_opencv = True
     import sdc.cv_ext
 
-config_transport_mpi_default = distutils_util.strtobool(os.getenv('SDC_CONFIG_MPI', 'True'))
+
+def strtobool(val):
+    '''Convert a string to True or False.'''
+    val = val.lower()
+    if val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return False
+    else:
+        return True
+
+
+config_transport_mpi_default = strtobool(os.getenv('SDC_CONFIG_MPI', 'True'))
 '''
 Default value for transport used if no function decorator controls the transport
 '''
@@ -58,9 +67,19 @@ Current value for transport controlled by decorator need to initialize this here
 because decorator called later then modules have been initialized
 '''
 
-config_pipeline_hpat_default = distutils_util.strtobool(os.getenv('SDC_CONFIG_PIPELINE_SDC', 'False'))
+config_pipeline_hpat_default = strtobool(os.getenv('SDC_CONFIG_PIPELINE_SDC', 'False'))
 '''
 Default value used to select compiler pipeline in a function decorator
+'''
+
+config_use_parallel_overloads = strtobool(os.getenv('SDC_AUTO_PARALLEL', 'False'))
+'''
+Default value used to select whether auto parallel would be applied to sdc functions
+'''
+
+config_inline_overloads = strtobool(os.getenv('SDC_AUTO_INLINE', 'False'))
+'''
+Default value used to select whether sdc functions would inline
 '''
 
 if not config_pipeline_hpat_default:
@@ -73,7 +92,7 @@ numba_compiler_define_nopython_pipeline_orig = None
 Default value for a pointer intended to use as Numba.DefaultPassBuilder.define_nopython_pipeline() in overloaded function
 '''
 
-test_expected_failure  = distutils_util.strtobool(os.getenv('SDC_TEST_EXPECTED_FAILURE', 'False'))
+test_expected_failure = strtobool(os.getenv('SDC_TEST_EXPECTED_FAILURE', 'False'))
 '''
 If True then replaces skip decorators to expectedFailure decorator.
 '''

--- a/sdc/config.py
+++ b/sdc/config.py
@@ -30,6 +30,7 @@ This is a set of configuration variables in SDC initialized at startup
 
 
 import os
+from distutils import util as distutils_util
 
 try:
     import pyarrow
@@ -48,12 +49,8 @@ else:
 
 
 def strtobool(val):
-    '''Convert a string to True or False.'''
-    val = val.lower()
-    if val in ('n', 'no', 'f', 'false', 'off', '0'):
-        return False
-    else:
-        return True
+    '''Convert string to True or False'''
+    return bool(distutils_util.strtobool(val))
 
 
 config_transport_mpi_default = strtobool(os.getenv('SDC_CONFIG_MPI', 'True'))

--- a/sdc/tests/test_series.py
+++ b/sdc/tests/test_series.py
@@ -37,7 +37,7 @@ from itertools import islice, permutations, product, combinations, combinations_
 from sdc.tests.test_base import TestCase
 from sdc.tests.test_utils import (
     count_array_REPs, count_parfor_REPs, count_array_OneDs, get_start_end,
-    skip_numba_jit, skip_sdc_jit, sdc_limitation)
+    skip_numba_jit, skip_sdc_jit, sdc_limitation, skip_parallel, skip_inline)
 from sdc.tests.gen_test_data import ParquetGenerator
 from numba import types
 from numba.config import IS_32BITS
@@ -612,6 +612,7 @@ class TestSeries(TestCase):
                             self.assertEqual(actual.index is S.index, expected.index is S.index)
                             self.assertEqual(actual.index is S.index, not deep)
 
+    @skip_parallel
     @skip_sdc_jit('Series.corr() parameter "min_periods" unsupported')
     def test_series_corr(self):
         def test_series_corr_impl(S1, S2, min_periods=None):
@@ -679,6 +680,8 @@ class TestSeries(TestCase):
         msg = 'Method corr(). The object min_periods'
         self.assertIn(msg, str(raises.exception))
 
+    @skip_parallel
+    @skip_inline
     def test_series_astype_int_to_str1(self):
         '''Verifies Series.astype implementation with function 'str' as argument
            converts integer series to series of strings
@@ -691,6 +694,8 @@ class TestSeries(TestCase):
         S = pd.Series(np.arange(n))
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
 
+    @skip_parallel
+    @skip_inline
     def test_series_astype_int_to_str2(self):
         '''Verifies Series.astype implementation with a string literal dtype argument
            converts integer series to series of strings
@@ -703,6 +708,8 @@ class TestSeries(TestCase):
         S = pd.Series(np.arange(n))
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
 
+    @skip_parallel
+    @skip_inline
     def test_series_astype_str_to_str1(self):
         '''Verifies Series.astype implementation with function 'str' as argument
            handles string series not changing it
@@ -714,6 +721,8 @@ class TestSeries(TestCase):
         S = pd.Series(['aa', 'bb', 'cc'])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
 
+    @skip_parallel
+    @skip_inline
     def test_series_astype_str_to_str2(self):
         '''Verifies Series.astype implementation with a string literal dtype argument
            handles string series not changing it
@@ -725,6 +734,8 @@ class TestSeries(TestCase):
         S = pd.Series(['aa', 'bb', 'cc'])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
 
+    @skip_parallel
+    @skip_inline
     def test_series_astype_str_to_str_index_str(self):
         '''Verifies Series.astype implementation with function 'str' as argument
            handles string series not changing it
@@ -738,6 +749,8 @@ class TestSeries(TestCase):
         S = pd.Series(['aa', 'bb', 'cc'], index=['d', 'e', 'f'])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
 
+    @skip_parallel
+    @skip_inline
     def test_series_astype_str_to_str_index_int(self):
         '''Verifies Series.astype implementation with function 'str' as argument
            handles string series not changing it
@@ -857,6 +870,8 @@ class TestSeries(TestCase):
         S = pd.Series(['3.24', '1E+05', '-1', '-1.3E-01', 'nan', 'inf'])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
 
+    @skip_parallel
+    @skip_inline
     def test_series_astype_str_index_str(self):
         '''Verifies Series.astype implementation with function 'str' as argument
            handles string series not changing it
@@ -869,6 +884,8 @@ class TestSeries(TestCase):
         S = pd.Series(['aa', 'bb', 'cc'], index=['a', 'b', 'c'])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
 
+    @skip_parallel
+    @skip_inline
     def test_series_astype_str_index_int(self):
         '''Verifies Series.astype implementation with function 'str' as argument
            handles string series not changing it
@@ -1462,6 +1479,7 @@ class TestSeries(TestCase):
         df = pd.DataFrame({'A': np.arange(n)})
         self.assertTrue(isinstance(hpat_func(df.A), np.ndarray))
 
+    @skip_parallel
     @skip_sdc_jit('No support of axis argument in old-style Series.fillna() impl')
     def test_series_fillna_axis1(self):
         '''Verifies Series.fillna() implementation handles 'index' as axis argument'''
@@ -1472,6 +1490,7 @@ class TestSeries(TestCase):
         S = pd.Series([1.0, 2.0, np.nan, 1.0, np.inf])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
 
+    @skip_parallel
     @skip_sdc_jit('No support of axis argument in old-style Series.fillna() impl')
     def test_series_fillna_axis2(self):
         '''Verifies Series.fillna() implementation handles 0 as axis argument'''
@@ -1482,6 +1501,7 @@ class TestSeries(TestCase):
         S = pd.Series([1.0, 2.0, np.nan, 1.0, np.inf])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
 
+    @skip_parallel
     @skip_sdc_jit('No support of axis argument in old-style Series.fillna() impl')
     def test_series_fillna_axis3(self):
         '''Verifies Series.fillna() implementation handles correct non-literal axis argument'''
@@ -1493,6 +1513,7 @@ class TestSeries(TestCase):
         for axis in [0, 'index']:
             pd.testing.assert_series_equal(hpat_func(S, axis), test_impl(S, axis))
 
+    @skip_parallel
     @skip_sdc_jit('BUG: old-style fillna impl returns series without index')
     def test_series_fillna_float_from_df(self):
         '''Verifies Series.fillna() applied to a named float Series obtained from a DataFrame'''
@@ -1504,6 +1525,7 @@ class TestSeries(TestCase):
         df = pd.DataFrame({'A': [1.0, 2.0, np.nan, 1.0, np.inf]})
         pd.testing.assert_series_equal(hpat_func(df.A), test_impl(df.A), check_names=False)
 
+    @skip_parallel
     @skip_sdc_jit('BUG: old-style fillna impl returns series without index')
     def test_series_fillna_float_index1(self):
         '''Verifies Series.fillna() implementation for float series with default index'''
@@ -1515,6 +1537,7 @@ class TestSeries(TestCase):
             S = pd.Series(data)
             pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
 
+    @skip_parallel
     @skip_sdc_jit('BUG: old-style fillna impl returns series without index')
     def test_series_fillna_float_index2(self):
         '''Verifies Series.fillna() implementation for float series with string index'''
@@ -1525,6 +1548,7 @@ class TestSeries(TestCase):
         S = pd.Series([1.0, 2.0, np.nan, 1.0, np.inf], ['a', 'b', 'c', 'd', 'e'])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
 
+    @skip_parallel
     @skip_sdc_jit('BUG: old-style fillna impl returns series without index')
     def test_series_fillna_float_index3(self):
         def test_impl(S):
@@ -1534,6 +1558,8 @@ class TestSeries(TestCase):
         S = pd.Series([1.0, 2.0, np.nan, 1.0, np.inf], index=[1, 2, 5, 7, 10])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
 
+    @skip_parallel
+    @skip_inline
     @skip_sdc_jit('BUG: old-style fillna impl returns series without index')
     def test_series_fillna_str_from_df(self):
         '''Verifies Series.fillna() applied to a named float Series obtained from a DataFrame'''
@@ -1546,6 +1572,8 @@ class TestSeries(TestCase):
         pd.testing.assert_series_equal(hpat_func(df.A),
                                        test_impl(df.A), check_names=False)
 
+    @skip_parallel
+    @skip_inline
     @skip_sdc_jit('BUG: old-style fillna impl returns series without index')
     def test_series_fillna_str_index1(self):
         '''Verifies Series.fillna() implementation for series of strings with default index'''
@@ -1556,6 +1584,8 @@ class TestSeries(TestCase):
         S = pd.Series(['aa', 'b', None, 'cccd', ''])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
 
+    @skip_parallel
+    @skip_inline
     @skip_sdc_jit('BUG: old-style fillna impl returns series without index')
     def test_series_fillna_str_index2(self):
         '''Verifies Series.fillna() implementation for series of strings with string index'''
@@ -1566,6 +1596,8 @@ class TestSeries(TestCase):
         S = pd.Series(['aa', 'b', None, 'cccd', ''], ['a', 'b', 'c', 'd', 'e'])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
 
+    @skip_parallel
+    @skip_inline
     @skip_sdc_jit('BUG: old-style fillna impl returns series without index')
     def test_series_fillna_str_index3(self):
         def test_impl(S):
@@ -1576,6 +1608,7 @@ class TestSeries(TestCase):
         S = pd.Series(['aa', 'b', None, 'cccd', ''], index=[1, 2, 5, 7, 10])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
 
+    @skip_parallel
     @skip_sdc_jit('BUG: old-style fillna impl returns series without index')
     def test_series_fillna_float_inplace1(self):
         '''Verifies Series.fillna() implementation for float series with default index and inplace argument True'''
@@ -1588,6 +1621,7 @@ class TestSeries(TestCase):
         S2 = S1.copy()
         pd.testing.assert_series_equal(hpat_func(S1), test_impl(S2))
 
+    @skip_parallel
     @unittest.skip('TODO: add reflection support and check method return value')
     def test_series_fillna_float_inplace2(self):
         '''Verifies Series.fillna(inplace=True) results are reflected back in the original float series'''
@@ -1601,6 +1635,7 @@ class TestSeries(TestCase):
         self.assertIsNone(test_impl(S2))
         pd.testing.assert_series_equal(S1, S2)
 
+    @skip_parallel
     def test_series_fillna_float_inplace3(self):
         '''Verifies Series.fillna() implementation correcly handles omitted inplace argument as default False'''
         def test_impl(S):
@@ -1612,6 +1647,7 @@ class TestSeries(TestCase):
         pd.testing.assert_series_equal(hpat_func(S1), test_impl(S1))
         pd.testing.assert_series_equal(S1, S2)
 
+    @skip_parallel
     def test_series_fillna_inplace_non_literal(self):
         '''Verifies Series.fillna() implementation handles only Boolean literals as inplace argument'''
         def test_impl(S, param):
@@ -1623,6 +1659,7 @@ class TestSeries(TestCase):
         expected = ValueError if sdc.config.config_pipeline_hpat_default else TypingError
         self.assertRaises(expected, hpat_func, S, True)
 
+    @skip_parallel
     @skip_numba_jit('TODO: investigate why Numba types inplace as bool (non-literal value)')
     def test_series_fillna_str_inplace1(self):
         '''Verifies Series.fillna() implementation for series of strings
@@ -1687,6 +1724,7 @@ class TestSeries(TestCase):
         S = pd.Series([pd.NaT, pd.Timestamp('1970-12-01'), pd.Timestamp('2012-07-25')])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
 
+    @skip_parallel
     def test_series_fillna_bool_no_index1(self):
         '''Verifies Series.fillna() implementation for bool series with default index'''
         def test_impl(S):
@@ -2570,6 +2608,7 @@ class TestSeries(TestCase):
         S = pd.Series([np.nan, -2., 3., 0.5E-01, 0xFF, 0o7, 0b101])
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
 
+    @skip_parallel
     def test_series_cov1(self):
         def test_impl(S1, S2):
             return S1.cov(S2)
@@ -4021,6 +4060,7 @@ class TestSeries(TestCase):
         B = np.random.ranf(n)
         pd.testing.assert_series_equal(hpat_func(A, B), test_impl(A, B))
 
+    @skip_parallel
     def test_series_sort_values_full(self):
         def test_impl(series, ascending, kind):
             return series.sort_values(axis=0, ascending=ascending, inplace=False, kind=kind, na_position='last')
@@ -4068,6 +4108,7 @@ class TestSeries(TestCase):
                         np.testing.assert_array_equal(ref_result.data, jit_result.data)
                         self.assertEqual(ref, jit)
 
+    @skip_parallel
     def test_series_sort_values_full_idx(self):
         def test_impl(series, ascending, kind):
             return series.sort_values(axis=0, ascending=ascending, inplace=False, kind=kind, na_position='last')
@@ -4688,6 +4729,7 @@ class TestSeries(TestCase):
             result = hpat_func(S)
             self.assertEqual(result, result_ref)
 
+    @skip_parallel
     @skip_sdc_jit('Series.cumsum() np.nan as input data unsupported')
     def test_series_cumsum(self):
         def test_impl():
@@ -4698,6 +4740,7 @@ class TestSeries(TestCase):
         cfunc = self.jit(pyfunc)
         pd.testing.assert_series_equal(pyfunc(), cfunc())
 
+    @skip_parallel
     @skip_sdc_jit('Series.cumsum() np.nan as input data unsupported')
     def test_series_cumsum_unboxing(self):
         def test_impl(s):
@@ -4710,6 +4753,7 @@ class TestSeries(TestCase):
             series = pd.Series(data)
             pd.testing.assert_series_equal(pyfunc(series), cfunc(series))
 
+    @skip_parallel
     @skip_sdc_jit('Series.cumsum() parameters "axis", "skipna" unsupported')
     def test_series_cumsum_full(self):
         def test_impl(s, axis, skipna):
@@ -4751,6 +4795,7 @@ class TestSeries(TestCase):
             msg = 'Method cumsum(). Unsupported parameters. Given axis: int'
             self.assertIn(msg, str(raises.exception))
 
+    @skip_parallel
     @skip_sdc_jit('Series.cov() parameter "min_periods" unsupported')
     def test_series_cov(self):
         def test_series_cov_impl(S1, S2, min_periods=None):
@@ -5146,6 +5191,7 @@ class TestSeries(TestCase):
                 B = pd.Series(np.arange(n)**2, index=np.arange(n, dtype=dtype_right))
                 pd.testing.assert_series_equal(hpat_func(A, B), test_impl(A, B), check_dtype=False)
 
+    @skip_parallel
     @skip_sdc_jit('Arithmetic operations on Series with non-default indexes are not supported in old-style')
     def test_series_operator_add_numeric_same_index_numeric_fixme(self):
         """ Same as test_series_operator_add_same_index_numeric but with w/a for the problem.
@@ -5167,6 +5213,7 @@ class TestSeries(TestCase):
                 B = pd.Series(np.arange(n)**2, index=np.arange(n, dtype=dtype_right))
                 pd.testing.assert_series_equal(hpat_func(A, B), test_impl(A, B), check_dtype=False)
 
+    @skip_parallel
     @skip_sdc_jit('Arithmetic operations on Series with non-default indexes are not supported in old-style')
     def test_series_operator_add_numeric_same_index_str(self):
         """Verifies implementation of Series.operator.add between two numeric Series with the same string indexes"""
@@ -5179,6 +5226,7 @@ class TestSeries(TestCase):
         B = pd.Series(np.arange(n)**2, index=['a', 'c', 'e', 'c', 'b', 'a', 'o'])
         pd.testing.assert_series_equal(hpat_func(A, B), test_impl(A, B), check_dtype=False, check_names=False)
 
+    @skip_parallel
     @skip_sdc_jit('Arithmetic operations on Series with non-default indexes are not supported in old-style')
     def test_series_operator_add_numeric_align_index_int(self):
         """Verifies implementation of Series.operator.add between two numeric Series with non-equal integer indexes"""
@@ -5195,6 +5243,7 @@ class TestSeries(TestCase):
         B = pd.Series(np.arange(n)**2, index=index_B)
         pd.testing.assert_series_equal(hpat_func(A, B), test_impl(A, B), check_dtype=False, check_names=False)
 
+    @skip_parallel
     @skip_sdc_jit('Arithmetic operations on Series with non-default indexes are not supported in old-style')
     def test_series_operator_add_numeric_align_index_str(self):
         """Verifies implementation of Series.operator.add between two numeric Series with non-equal string indexes"""
@@ -5228,6 +5277,7 @@ class TestSeries(TestCase):
         B = pd.Series(np.arange(n)**2, index=index_B)
         pd.testing.assert_series_equal(hpat_func(A, B), test_impl(A, B), check_dtype=False, check_names=False)
 
+    @skip_parallel
     @skip_sdc_jit('Arithmetic operations on Series with non-default indexes are not supported in old-style')
     def test_series_operator_add_numeric_align_index_other_dtype(self):
         """Verifies implementation of Series.operator.add between two numeric Series
@@ -5253,6 +5303,7 @@ class TestSeries(TestCase):
         B = pd.Series(np.arange(size_B)**2)
         pd.testing.assert_series_equal(hpat_func(A, B), test_impl(A, B), check_dtype=False, check_names=False)
 
+    @skip_parallel
     @skip_sdc_jit('Arithmetic operations on Series requiring alignment of indexes are not supported in old-style')
     def test_series_operator_add_align_index_int_capacity(self):
         """Verifies implementation of Series.operator.add and alignment of numeric indexes of large size"""

--- a/sdc/tests/test_utils.py
+++ b/sdc/tests/test_utils.py
@@ -32,6 +32,7 @@ import numpy as np
 import sdc
 import numba
 
+from sdc.config import (config_use_parallel_overloads, config_inline_overloads)
 
 test_global_input_data_unicode_kind4 = [
     '¡Y tú quién te crees?',
@@ -150,3 +151,21 @@ def skip_sdc_jit(msg_or_func=None):
 
 def sdc_limitation(func):
     return unittest.expectedFailure(func)
+
+
+def skip_parallel(msg_or_func):
+    msg, func = msg_and_func(msg_or_func)
+    wrapper = unittest.skipIf(config_use_parallel_overloads, msg or "fails in parallel mode")
+    if sdc.config.test_expected_failure:
+        wrapper = unittest.expectedFailure
+    # wrapper = lambda f: f  # disable skipping
+    return wrapper(func) if func else wrapper
+
+
+def skip_inline(msg_or_func):
+    msg, func = msg_and_func(msg_or_func)
+    wrapper = unittest.skipIf(config_inline_overloads, msg or "fails in inline mode")
+    if sdc.config.test_expected_failure:
+        wrapper = unittest.expectedFailure
+    # wrapper = lambda f: f  # disable skipping
+    return wrapper(func) if func else wrapper

--- a/sdc/utils.py
+++ b/sdc/utils.py
@@ -42,6 +42,7 @@ import numpy as np
 import sdc
 from sdc.str_ext import string_type, list_string_array_type
 from sdc.str_arr_ext import string_array_type, num_total_chars, pre_alloc_string_array
+from sdc.config import (config_use_parallel_overloads, config_inline_overloads)
 from enum import Enum
 import types as pytypes
 from numba.extending import overload, overload_method, overload_attribute
@@ -565,13 +566,34 @@ def update_globals(func, glbls):
         func.__globals__.update(glbls)
 
 
-def sdc_overload(func, jit_options={}, strict=True, inline='never'):
+def sdc_overload(func, jit_options={}, strict=True, inline=None):
+    if 'parallel' not in jit_options:
+        jit_options = jit_options.copy()
+        jit_options.update({'parallel': config_use_parallel_overloads})
+
+    if inline is None:
+        inline = 'always' if config_inline_overloads else 'never'
+
     return overload(func, jit_options=jit_options, strict=strict, inline=inline)
 
 
-def sdc_overload_method(typ, name, jit_options={}, strict=True, inline='never'):
+def sdc_overload_method(typ, name, jit_options={}, strict=True, inline=None):
+    if 'parallel' not in jit_options:
+        jit_options = jit_options.copy()
+        jit_options.update({'parallel': config_use_parallel_overloads})
+
+    if inline is None:
+        inline = 'always' if config_inline_overloads else 'never'
+
     return overload_method(typ, name, jit_options=jit_options, strict=strict, inline=inline)
 
 
-def sdc_overload_attribute(typ, name, jit_options={}, strict=True, inline='never'):
+def sdc_overload_attribute(typ, name, jit_options={}, strict=True, inline=None):
+    if 'parallel' not in jit_options:
+        jit_options = jit_options.copy()
+        jit_options.update({'parallel': config_use_parallel_overloads})
+
+    if inline is None:
+        inline = 'always' if config_inline_overloads else 'never'
+
     return overload_attribute(typ, name, jit_options=jit_options, strict=strict, inline=inline)


### PR DESCRIPTION
Introduce the way to configure default behavior of sdc_overloads:

1. Config parameter `config_use_parallel_overloads` and environment variable `SDC_AUTO_PARALLEL` which config if `parallel` option is enabled or disabled for all sdc overloads. Default is `False`
2. Config parameter `config_inline_overloads` and environment variable `SDC_AUTO_INLINE` which config is `inline` option is enabled for all sdc overloads. Default is `False`