### PR TITLE
Fix README.md: minimize conda environment dependencies.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ Building on Linux with setuptools
 ::
 
     PYVER=<3.6 or 3.7>
-    conda create -n SDC -q -y -c numba -c conda-forge -c defaults numba mpich pyarrow=0.15.0 arrow-cpp=0.15.0 gcc_linux-64 gxx_linux-64 gfortran_linux-64 scipy pandas boost python=$PYVER
+    conda create -n SDC -q -y -c numba -c defaults -c conda-forge python=$PYVER numba pandas scipy mpich pyarrow=0.15.1 gcc_linux-64 gxx_linux-64
     source activate SDC
     git clone https://github.com/IntelPython/sdc
     cd sdc


### PR DESCRIPTION
For Linux.
1. Chennel `defaults` is before channel `conda-forge`
2. `pyarrow` depends on `arrow-cpp`, so installing `arrow-cpp` is not required.
3. `boost` is not required.
4. It is better to use `pyarrow` 0.15.1 because it contains latest patches (1 month period from 0.15.0).
5. `gfortran_linux-64` is not required.