### PR TITLE
Use prange in apply

### DIFF
--- a/sdc/datatypes/pandas_series_functions/apply.py
+++ b/sdc/datatypes/pandas_series_functions/apply.py
@@ -106,6 +106,7 @@ def hpat_pandas_series_apply(self, func, convert_dtype=True, args=()):
         output_arr = numpy.empty(length, dtype=output_type)
 
         for i in numba.prange(length):
+            # Numba issue https://github.com/numba/numba/issues/5065
             # output_arr[i] = func(input_arr[i], *args)
             output_arr[i] = func(input_arr[i])
 

--- a/sdc/datatypes/pandas_series_functions/apply.py
+++ b/sdc/datatypes/pandas_series_functions/apply.py
@@ -49,31 +49,31 @@ def hpat_pandas_series_apply(self, func, convert_dtype=True, args=()):
     Examples
     --------
     .. literalinclude:: ../../../examples/series/series_apply.py
-       :language: python
-       :lines: 33-
-       :caption: Square the values by defining a function and passing it as an argument to `apply()`.
-       :name: ex_series_apply
+        :language: python
+        :lines: 33-
+        :caption: Square the values by defining a function and passing it as an argument to `apply()`.
+        :name: ex_series_apply
 
     .. command-output:: python ./series/series_apply.py
-       :cwd: ../../../examples
+        :cwd: ../../../examples
 
     .. literalinclude:: ../../../examples/series/series_apply_lambda.py
-       :language: python
-       :lines: 33-
-       :caption: Square the values by passing an anonymous function as an argument to `apply()`.
-       :name: ex_series_apply_lambda
+        :language: python
+        :lines: 33-
+        :caption: Square the values by passing an anonymous function as an argument to `apply()`.
+        :name: ex_series_apply_lambda
 
     .. command-output:: python ./series/series_apply_lambda.py
-       :cwd: ../../../examples
+        :cwd: ../../../examples
 
     .. literalinclude:: ../../../examples/series/series_apply_log.py
-       :language: python
-       :lines: 33-
-       :caption: Use a function from the Numpy library.
-       :name: ex_series_apply_log
+        :language: python
+        :lines: 33-
+        :caption: Use a function from the Numpy library.
+        :name: ex_series_apply_log
 
     .. command-output:: python ./series/series_apply_log.py
-       :cwd: ../../../examples
+        :cwd: ../../../examples
 
     .. seealso::
 
@@ -88,7 +88,7 @@ def hpat_pandas_series_apply(self, func, convert_dtype=True, args=()):
     *************************************************
 
     .. only:: developer
-       Test: python -m sdc.runtests sdc.tests.test_series_apply
+        Test: python -m sdc.runtests sdc.tests.test_series_apply
     """
 
     ty_checker = TypeChecker("Method apply().")

--- a/sdc/datatypes/pandas_series_functions/apply.py
+++ b/sdc/datatypes/pandas_series_functions/apply.py
@@ -94,11 +94,16 @@ def hpat_pandas_series_apply(self, func, convert_dtype=True, args=()):
     ty_checker = TypeChecker("Method apply().")
     ty_checker.check(self, SeriesType)
 
+    if isinstance(func, numba.types.Dispatcher):
+        output_type = func.dispatcher.get_call_template([self.dtype], {})[0].cases[0].return_type
+    else:
+        output_type = self.dtype
+
     def impl(self, func, convert_dtype=True, args=()):
         input_arr = self._data
         length = len(input_arr)
 
-        output_arr = numpy.empty(length, dtype=numba.types.float64)
+        output_arr = numpy.empty(length, dtype=output_type)
 
         for i in numba.prange(length):
             output_arr[i] = func(input_arr[i], *args)

--- a/sdc/datatypes/pandas_series_functions/apply.py
+++ b/sdc/datatypes/pandas_series_functions/apply.py
@@ -106,7 +106,8 @@ def hpat_pandas_series_apply(self, func, convert_dtype=True, args=()):
         output_arr = numpy.empty(length, dtype=output_type)
 
         for i in numba.prange(length):
-            output_arr[i] = func(input_arr[i], *args)
+            # output_arr[i] = func(input_arr[i], *args)
+            output_arr[i] = func(input_arr[i])
 
         return pandas.Series(output_arr, index=self._index, name=self._name)
 

--- a/sdc/tests/test_series_apply.py
+++ b/sdc/tests/test_series_apply.py
@@ -100,7 +100,6 @@ class TestSeries_apply(object):
         S = pd.Series(DATA)
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
 
-    @skip_numba_jit("'args' in apply is not supported")
     @skip_sdc_jit("'args' in apply is not supported")
     def test_series_apply_args(self):
         @numba.extending.register_jitable

--- a/sdc/tests/test_series_apply.py
+++ b/sdc/tests/test_series_apply.py
@@ -110,6 +110,7 @@ class TestSeries_apply(object):
         S = pd.Series(DATA)
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
 
+    @skip_numba_jit("'args' in apply is not supported")
     @skip_sdc_jit("'args' in apply is not supported")
     def test_series_apply_args(self):
         @numba.extending.register_jitable

--- a/sdc/tests/test_series_apply.py
+++ b/sdc/tests/test_series_apply.py
@@ -54,6 +54,16 @@ class TestSeries_apply(object):
         S = pd.Series(DATA)
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
 
+    def test_series_apply_convert_type(self):
+        def test_impl(S):
+            def to_int(x):
+                return int(x)
+            return S.apply(to_int)
+        hpat_func = self.jit(test_impl)
+
+        S = pd.Series(DATA)
+        pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
+
     @skip_sdc_jit("Series.index values are different")
     def test_series_apply_index(self):
         test_impl = series_apply_square_usecase

--- a/sdc/tests/tests_perf/test_perf_series.py
+++ b/sdc/tests/tests_perf/test_perf_series.py
@@ -209,7 +209,7 @@ def {func_name}(self):
 
 cases = [
     ('abs', '', [3 * 10 ** 8]),
-    ('apply', 'lambda x: x', [10 ** 7]),
+    ('apply', 'lambda x: x * 2', [10 ** 7]),
     ('argsort', '', [10 ** 5]),
     ('at', '', [10 ** 7], 'at[3]'),
     ('copy', '', [10 ** 8]),


### PR DESCRIPTION
`args` are not supported still.
This PR makes possible to use func() which converts type. It is implemented using get_call_type().
Also it uses prange to make `apply()` parallel.