### PR TITLE
Add params to benchmark test case name

### DIFF
--- a/sdc/tests/tests_perf/generator.py
+++ b/sdc/tests/tests_perf/generator.py
@@ -71,9 +71,13 @@ def gen_test(test_case, prefix):
 
     skip = '@skip_numba_jit\n' if test_case.skip else ''
 
+    test_name = test_case.name
+    if test_case.params:
+        test_name = f'{test_name}({test_case.params})'
+
     func_text = f"""
 {skip}def {func_name}(self):
-  self._test_case(usecase, name='{test_case.name}', total_data_length={test_case.size},
+  self._test_case(usecase, name='{test_name}', total_data_length={test_case.size},
                   data_num={test_case.data_num}, input_data={test_case.input_data})
 """
 

--- a/sdc/tests/tests_perf/test_perf_series.py
+++ b/sdc/tests/tests_perf/test_perf_series.py
@@ -134,7 +134,7 @@ cases = [
     TC(name='lt', size=[10 ** 7], params='other', data_num=2),
     TC(name='map', size=[10 ** 7], params='lambda x: x * 2'),
     TC(name='map', size=[10 ** 7], params='{2.: 42., 4.: 3.14}'),
-    TC(name='max', size=[10 ** 8]),
+    TC(name='max', size=[10 ** 8], params='skipna=True'),
     TC(name='max', size=[10 ** 8], params='skipna=False'),
     TC(name='mean', size=[10 ** 8]),
     TC(name='median', size=[10 ** 8]),


### PR DESCRIPTION
This PR fixes problem when two functions with different parameters displays as one test case:
![before](https://user-images.githubusercontent.com/1541421/73432343-963abd80-4353-11ea-8aca-2016c900acf1.png)
Now you could see separated functions with parameters:
![after](https://user-images.githubusercontent.com/1541421/73432348-99ce4480-4353-11ea-83bd-a005d59ca409.png)
