### PR TITLE
Add decorator sdc_register_jitable

### DIFF
--- a/sdc/datatypes/common_functions.py
+++ b/sdc/datatypes/common_functions.py
@@ -44,7 +44,7 @@ import sdc
 from sdc.str_arr_ext import (string_array_type, num_total_chars, append_string_array_to,
                              str_arr_is_na, pre_alloc_string_array, str_arr_set_na,
                              cp_str_list_to_array, make_str_arr_from_list)
-from sdc.utils import sdc_overload
+from sdc.utils import sdc_overload, sdc_register_jitable
 
 
 class TypeChecker:
@@ -208,7 +208,7 @@ def hpat_arrays_append_overload(A, B):
             return _append_list_string_array_impl
 
 
-@register_jitable
+@sdc_register_jitable
 def fill_array(data, size, fill_value=numpy.nan, push_back=True):
     """
     Fill array with given values to reach the size
@@ -220,7 +220,7 @@ def fill_array(data, size, fill_value=numpy.nan, push_back=True):
     return numpy.append(numpy.repeat(fill_value, size - data.size), data)
 
 
-@register_jitable
+@sdc_register_jitable
 def fill_str_array(data, size, push_back=True):
     """
     Fill StringArrayType array with given values to reach the size

--- a/sdc/datatypes/hpat_pandas_series_rolling_functions.py
+++ b/sdc/datatypes/hpat_pandas_series_rolling_functions.py
@@ -36,7 +36,7 @@ from numba.types import (float64, Boolean, Integer, NoneType, Number,
 
 from sdc.datatypes.common_functions import TypeChecker
 from sdc.datatypes.hpat_pandas_series_rolling_types import SeriesRollingType
-from sdc.utils import sdc_overload_method
+from sdc.utils import sdc_overload_method, sdc_register_jitable
 
 
 # disabling parallel execution for rolling due to numba issue https://github.com/numba/numba/issues/5098
@@ -90,13 +90,13 @@ hpat_pandas_series_rolling_docstring_tmpl = """
 """
 
 
-@register_jitable
+@sdc_register_jitable
 def arr_apply(arr, func):
     """Apply function for values"""
     return func(arr)
 
 
-@register_jitable
+@sdc_register_jitable
 def arr_corr(x, y):
     """Calculate correlation of values"""
     if len(x) == 0:
@@ -105,13 +105,13 @@ def arr_corr(x, y):
     return numpy.corrcoef(x, y)[0, 1]
 
 
-@register_jitable
+@sdc_register_jitable
 def arr_nonnan_count(arr):
     """Count non-NaN values"""
     return len(arr) - numpy.isnan(arr).sum()
 
 
-@register_jitable
+@sdc_register_jitable
 def arr_cov(x, y, ddof):
     """Calculate covariance of values 1D arrays x and y of the same size"""
     if len(x) == 0:
@@ -120,7 +120,7 @@ def arr_cov(x, y, ddof):
     return numpy.cov(x, y, ddof=ddof)[0, 1]
 
 
-@register_jitable
+@sdc_register_jitable
 def _moment(arr, moment):
     mn = numpy.mean(arr)
     s = numpy.power((arr - mn), moment)
@@ -128,7 +128,7 @@ def _moment(arr, moment):
     return numpy.mean(s)
 
 
-@register_jitable
+@sdc_register_jitable
 def arr_kurt(arr):
     """Calculate unbiased kurtosis of values"""
     n = len(arr)
@@ -145,7 +145,7 @@ def arr_kurt(arr):
     return val
 
 
-@register_jitable
+@sdc_register_jitable
 def arr_max(arr):
     """Calculate maximum of values"""
     if len(arr) == 0:
@@ -154,7 +154,7 @@ def arr_max(arr):
     return arr.max()
 
 
-@register_jitable
+@sdc_register_jitable
 def arr_mean(arr):
     """Calculate mean of values"""
     if len(arr) == 0:
@@ -163,7 +163,7 @@ def arr_mean(arr):
     return arr.mean()
 
 
-@register_jitable
+@sdc_register_jitable
 def arr_median(arr):
     """Calculate median of values"""
     if len(arr) == 0:
@@ -172,7 +172,7 @@ def arr_median(arr):
     return numpy.median(arr)
 
 
-@register_jitable
+@sdc_register_jitable
 def arr_min(arr):
     """Calculate minimum of values"""
     if len(arr) == 0:
@@ -181,7 +181,7 @@ def arr_min(arr):
     return arr.min()
 
 
-@register_jitable
+@sdc_register_jitable
 def arr_quantile(arr, q):
     """Calculate quantile of values"""
     if len(arr) == 0:
@@ -190,7 +190,7 @@ def arr_quantile(arr, q):
     return numpy.quantile(arr, q)
 
 
-@register_jitable
+@sdc_register_jitable
 def _moment(arr, moment):
     mn = numpy.mean(arr)
     s = numpy.power((arr - mn), moment)
@@ -198,7 +198,7 @@ def _moment(arr, moment):
     return numpy.mean(s)
 
 
-@register_jitable
+@sdc_register_jitable
 def arr_skew(arr):
     """Calculate unbiased skewness of values"""
     n = len(arr)
@@ -215,19 +215,19 @@ def arr_skew(arr):
     return val
 
 
-@register_jitable
+@sdc_register_jitable
 def arr_std(arr, ddof):
     """Calculate standard deviation of values"""
     return arr_var(arr, ddof) ** 0.5
 
 
-@register_jitable
+@sdc_register_jitable
 def arr_sum(arr):
     """Calculate sum of values"""
     return arr.sum()
 
 
-@register_jitable
+@sdc_register_jitable
 def arr_var(arr, ddof):
     """Calculate unbiased variance of values"""
     length = len(arr)

--- a/sdc/utils.py
+++ b/sdc/utils.py
@@ -594,7 +594,7 @@ def sdc_overload(func, jit_options={}, parallel=None, strict=True, inline=None):
 
 def patched_register_jitable(*args, **kwargs):
     """
-    register_jitable patched according this:
+    register_jitable patched according to this:
     https://github.com/numba/numba/issues/5142#issuecomment-579704346
     """
     def wrap(fn):

--- a/sdc/utils.py
+++ b/sdc/utils.py
@@ -46,6 +46,7 @@ from sdc.config import (config_use_parallel_overloads, config_inline_overloads)
 from enum import Enum
 import types as pytypes
 from numba.extending import overload, overload_method, overload_attribute
+from numba.extending import register_jitable
 
 
 # int values for types to pass to C code
@@ -589,6 +590,20 @@ def sdc_overload(func, jit_options={}, parallel=None, strict=True, inline=None):
         inline = 'always' if config_inline_overloads else 'never'
 
     return overload(func, jit_options=jit_options, strict=strict, inline=inline)
+
+
+def sdc_register_jitable(*args, **kwargs):
+    updated_kwargs = kwargs.copy()
+    updated_kwargs['parallel'] = updated_kwargs.get('parallel', config_use_parallel_overloads)
+    updated_kwargs['inline'] = updated_kwargs.get('inline', 'always' if config_inline_overloads else 'never')
+
+    def wrap(fn):
+        return register_jitable(**updated_kwargs)(fn)
+
+    if kwargs:
+        return wrap
+    else:
+        return wrap(*args)
 
 
 def sdc_overload_method(typ, name, jit_options={}, parallel=None, strict=True, inline=None):

--- a/sdc/utils.py
+++ b/sdc/utils.py
@@ -592,13 +592,32 @@ def sdc_overload(func, jit_options={}, parallel=None, strict=True, inline=None):
     return overload(func, jit_options=jit_options, strict=strict, inline=inline)
 
 
+def patched_register_jitable(*args, **kwargs):
+    """
+    register_jitable patched according this:
+    https://github.com/numba/numba/issues/5142#issuecomment-579704346
+    """
+    def wrap(fn):
+        # It is just a wrapper for @overload
+        inline = kwargs.pop('inline', 'never')
+        @overload(fn, jit_options=kwargs, inline=inline, strict=False)
+        def ov_wrap(*args, **kwargs):
+            return fn
+        return fn
+
+    if kwargs:
+        return wrap
+    else:
+        return wrap(*args)
+
+
 def sdc_register_jitable(*args, **kwargs):
     updated_kwargs = kwargs.copy()
     updated_kwargs['parallel'] = updated_kwargs.get('parallel', config_use_parallel_overloads)
     updated_kwargs['inline'] = updated_kwargs.get('inline', 'always' if config_inline_overloads else 'never')
 
     def wrap(fn):
-        return register_jitable(**updated_kwargs)(fn)
+        return patched_register_jitable(**updated_kwargs)(fn)
 
     if kwargs:
         return wrap


### PR DESCRIPTION
This PR adds decorator `sdc_register_jitable` which wraps `numba.extending.register_jitable` decorator.
`sdc_register_jitable` takes default parameters for `parallel` and `inline` from `SDC_AUTO_PARALLEL` and `SDC_AUTO_INLINE` environment variables.

I am planning to use it in #541 and #535 and other PRs for improving scalability.