### PR TITLE
Replace pandas<1.0.0a0 to pandas=0.25 due to the buildscripts issue.

### DIFF
--- a/buildscripts/sdc-conda-recipe/meta.yaml
+++ b/buildscripts/sdc-conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set NUMBA_VERSION = "==0.46" %}
-{% set PANDAS_VERSION = "<1.0.0a0" %}
+{% set PANDAS_VERSION = "==0.25" %}
 {% set PYARROW_VERSION = "==0.15.1" %}
 {% set ARROW_CPP_VERSION = "==0.15.1" %}
 


### PR DESCRIPTION
This PR fixes internal [benchmarking job](https://teamcity-or.intel.com/viewLog.html?buildId=4541756&buildTypeId=Sat_Sdc_Linux_SdcPy37numpy116_Testing_SdcBenchmarks&tab=buildResultsDiv).