### PR TITLE
Add test for Series([np.nan]).min(skipna=False)

### DIFF
--- a/sdc/tests/test_series.py
+++ b/sdc/tests/test_series.py
@@ -2494,6 +2494,24 @@ class TestSeries(
             result = hpat_func(S, param_skipna)
             self.assertEqual(result, result_ref)
 
+    @unittest.expectedFailure
+    def test_series_min_param_fail(self):
+        def test_impl(S, param_skipna):
+            return S.min(skipna=param_skipna)
+
+        hpat_func = self.jit(test_impl)
+
+        cases = [
+            ([2., 3., 1, np.inf, -1000, np.nan], False),  # min == np.nan
+        ]
+
+        for input_data, param_skipna in cases:
+            S = pd.Series(input_data)
+
+            result_ref = test_impl(S, param_skipna)
+            result = hpat_func(S, param_skipna)
+            self.assertEqual(result, result_ref)
+
     def test_series_max(self):
         def test_impl(S):
             return S.max()


### PR DESCRIPTION
I have added this test to show that our implementation differs from Pandas with skipna=False. We return -1000 while Pandas returns nan.

Related issue https://github.com/numba/numba/issues/4125 and PR https://github.com/numba/numba/pull/4210