### PR TITLE
Remove warming up from TestBase._test_jitted()

### DIFF
--- a/sdc/tests/tests_perf/test_perf_base.py
+++ b/sdc/tests/tests_perf/test_perf_base.py
@@ -44,9 +44,6 @@ class TestBase(unittest.TestCase):
 
         cfunc = numba.njit(pyfunc)
 
-        # Warming up
-        cfunc(*args, **kwargs)
-
         # execution and boxing time
         record["test_results"], record["boxing_results"] = \
             get_times(cfunc, *args, **kwargs)


### PR DESCRIPTION
This PR make a fix for #568.
#563 moved warming up to `get_times()` but #568 moved it back and created duplication.