### PR TITLE
Rename methods test_jit() and test_py() to make it not considered as …

### DIFF
--- a/sdc/tests/tests_perf/test_perf_base.py
+++ b/sdc/tests/tests_perf/test_perf_base.py
@@ -55,13 +55,13 @@ class TestBase(unittest.TestCase):
         record["test_results"], _ = \
             get_times(pyfunc, *args, **kwargs)
 
-    def test_jit(self, pyfunc, base, *args):
+    def _test_jit(self, pyfunc, base, *args):
         record = base.copy()
         record["test_type"] = 'SDC'
         self._test_jitted(pyfunc, record, *args)
         self.test_results.add(**record)
 
-    def test_py(self, pyfunc, base, *args):
+    def _test_py(self, pyfunc, base, *args):
         record = base.copy()
         record["test_type"] = 'Python'
         self._test_python(pyfunc, record, *args)

--- a/sdc/tests/tests_perf/test_perf_df.py
+++ b/sdc/tests/tests_perf/test_perf_df.py
@@ -66,8 +66,8 @@ class TestDataFrameMethods(TestBase):
                 extra_data = np.random.ranf(data_length)
                 args.append(pandas.DataFrame({f"f{i}": extra_data for i in range(3)}))
 
-            self.test_jit(pyfunc, base, *args)
-            self.test_py(pyfunc, base, *args)
+            self._test_jit(pyfunc, base, *args)
+            self._test_py(pyfunc, base, *args)
 
 
 cases = [

--- a/sdc/tests/tests_perf/test_perf_series.py
+++ b/sdc/tests/tests_perf/test_perf_series.py
@@ -68,8 +68,8 @@ class TestSeriesMethods(TestBase):
                 extra_data = np.random.ranf(data_length)
                 args.append(pandas.Series(extra_data))
 
-            self.test_jit(pyfunc, base, *args)
-            self.test_py(pyfunc, base, *args)
+            self._test_jit(pyfunc, base, *args)
+            self._test_py(pyfunc, base, *args)
 
 
 cases = [

--- a/sdc/tests/tests_perf/test_perf_series_operators.py
+++ b/sdc/tests/tests_perf/test_perf_series_operators.py
@@ -73,8 +73,8 @@ class TestSeriesOperatorMethods(TestBase):
                 extra_data = np.random.ranf(data_length)
                 args.append(pandas.Series(extra_data))
 
-            self.test_jit(pyfunc, base, *args)
-            self.test_py(pyfunc, base, *args)
+            self._test_jit(pyfunc, base, *args)
+            self._test_py(pyfunc, base, *args)
 
 
 cases = [

--- a/sdc/tests/tests_perf/test_perf_series_str.py
+++ b/sdc/tests/tests_perf/test_perf_series_str.py
@@ -75,8 +75,8 @@ class TestSeriesStringMethods(TestBase):
 
             args = [test_data]
 
-            self.test_jit(pyfunc, base, *args)
-            self.test_py(pyfunc, base, *args)
+            self._test_jit(pyfunc, base, *args)
+            self._test_py(pyfunc, base, *args)
 
 
 cases = [


### PR DESCRIPTION
…test cases.