### PR TITLE
Fix names for perf test cases

### DIFF
--- a/sdc/tests/tests_perf/test_perf_df_rolling.py
+++ b/sdc/tests/tests_perf/test_perf_df_rolling.py
@@ -137,7 +137,7 @@ class TestDFRollingMethods(TestBase):
         full_input_data_length = sum(len(i) for i in input_data)
         for data_length in self.total_data_length[name]:
             base = {
-                'test_name': f'DF.rolling.{name}',
+                'test_name': f'DataFrame.rolling.{name}',
                 'data_size': data_length,
             }
             data = perf_data_gen_fixed_len(input_data, full_input_data_length,

--- a/sdc/tests/tests_perf/test_perf_series_operators.py
+++ b/sdc/tests/tests_perf/test_perf_series_operators.py
@@ -68,19 +68,19 @@ class TestSeriesOperatorMethods(TestBase):
 
 
 cases = [
-    TC(name='operator_add', size=[10 ** 7], call_expr='A + B', usecase_params='A, B', data_num=2),
-    TC(name='operator_eq', size=[10 ** 7], call_expr='A == B', usecase_params='A, B', data_num=2),
-    TC(name='operator_floordiv', size=[10 ** 7], call_expr='A // B', usecase_params='A, B', data_num=2),
-    TC(name='operator_ge', size=[10 ** 7], call_expr='A >= B', usecase_params='A, B', data_num=2),
-    TC(name='operator_gt', size=[10 ** 7], call_expr='A > B', usecase_params='A, B', data_num=2),
-    TC(name='operator_le', size=[10 ** 7], call_expr='A <= B', usecase_params='A, B', data_num=2),
-    TC(name='operator_lt', size=[10 ** 7], call_expr='A < B', usecase_params='A, B', data_num=2),
-    TC(name='operator_mod', size=[10 ** 7], call_expr='A % B', usecase_params='A, B', data_num=2),
-    TC(name='operator_mul', size=[10 ** 7], call_expr='A * B', usecase_params='A, B', data_num=2),
-    TC(name='operator_ne', size=[10 ** 7], call_expr='A != B', usecase_params='A, B', data_num=2),
-    TC(name='operator_pow', size=[10 ** 7], call_expr='A ** B', usecase_params='A, B', data_num=2),
-    TC(name='operator_sub', size=[10 ** 7], call_expr='A - B', usecase_params='A, B', data_num=2),
-    TC(name='operator_truediv', size=[10 ** 7], call_expr='A / B', usecase_params='A, B', data_num=2),
+    TC(name='operator.add', size=[10 ** 7], call_expr='A + B', usecase_params='A, B', data_num=2),
+    TC(name='operator.eq', size=[10 ** 7], call_expr='A == B', usecase_params='A, B', data_num=2),
+    TC(name='operator.floordiv', size=[10 ** 7], call_expr='A // B', usecase_params='A, B', data_num=2),
+    TC(name='operator.ge', size=[10 ** 7], call_expr='A >= B', usecase_params='A, B', data_num=2),
+    TC(name='operator.gt', size=[10 ** 7], call_expr='A > B', usecase_params='A, B', data_num=2),
+    TC(name='operator.le', size=[10 ** 7], call_expr='A <= B', usecase_params='A, B', data_num=2),
+    TC(name='operator.lt', size=[10 ** 7], call_expr='A < B', usecase_params='A, B', data_num=2),
+    TC(name='operator.mod', size=[10 ** 7], call_expr='A % B', usecase_params='A, B', data_num=2),
+    TC(name='operator.mul', size=[10 ** 7], call_expr='A * B', usecase_params='A, B', data_num=2),
+    TC(name='operator.ne', size=[10 ** 7], call_expr='A != B', usecase_params='A, B', data_num=2),
+    TC(name='operator.pow', size=[10 ** 7], call_expr='A ** B', usecase_params='A, B', data_num=2),
+    TC(name='operator.sub', size=[10 ** 7], call_expr='A - B', usecase_params='A, B', data_num=2),
+    TC(name='operator.truediv', size=[10 ** 7], call_expr='A / B', usecase_params='A, B', data_num=2),
 ]
 
 generate_test_cases(cases, TestSeriesOperatorMethods, 'series')


### PR DESCRIPTION
Change usecase names for better matching methods names in reports:
`DF.rolling.*` -> `DataFrame.rolling.*`
`Series.operator_*` -> `Series.operator.*`