### PR TITLE
Remove test that causes segfault

### DIFF
--- a/sdc/tests/test_strings.py
+++ b/sdc/tests/test_strings.py
@@ -317,14 +317,6 @@ class TestStrings(TestCase):
         A = np.array(['AA', 'B'])
         self.assertEqual(hpat_func(A), test_impl(A))
 
-    @unittest.skipIf(platform.system() == 'Windows', "no glob support on windows yet")
-    def test_glob(self):
-        def test_impl():
-            glob.glob("*py")
-        hpat_func = self.jit(test_impl)
-
-        self.assertEqual(hpat_func(), test_impl())
-
     def test_set_string(self):
         def test_impl():
             s = sdc.set_ext.init_set_string()

--- a/sdc/tests/test_strings.py
+++ b/sdc/tests/test_strings.py
@@ -317,6 +317,14 @@ class TestStrings(TestCase):
         A = np.array(['AA', 'B'])
         self.assertEqual(hpat_func(A), test_impl(A))
 
+    @unittest.skip("No glob support on windows yet. Segfault on Linux if no files found by pattern")
+    def test_glob(self):
+        def test_impl():
+            glob.glob("*py")
+        hpat_func = self.jit(test_impl)
+
+        self.assertEqual(hpat_func(), test_impl())
+
     def test_set_string(self):
         def test_impl():
             s = sdc.set_ext.init_set_string()


### PR DESCRIPTION
If glob(pattern) cannot find files by pattern, it causes core dump