### PR TITLE
Simplify series.rolling methods generator + median

### DIFF
--- a/sdc/tests/tests_perf/test_perf_series_rolling.py
+++ b/sdc/tests/tests_perf/test_perf_series_rolling.py
@@ -86,6 +86,7 @@ class TestSeriesRollingMethods(TestBase):
         super().setUpClass()
         cls.map_ncalls_dlength = {
             'mean': (100, [8 * 10 ** 5]),
+            'median': (10, [10 ** 5]),
             'sum': (100, [8 * 10 ** 5]),
         }
 
@@ -128,6 +129,9 @@ class TestSeriesRollingMethods(TestBase):
     def test_series_rolling_mean(self):
         self._test_series_rolling_method('mean')
 
+    def test_series_rolling_median(self):
+        self._test_series_rolling_method('median')
+
     def test_series_rolling_sum(self):
         self._test_series_rolling_method('sum')
 
@@ -139,7 +143,6 @@ cases = [
     TC(name='cov', size=[10 ** 7]),
     TC(name='kurt', size=[10 ** 7]),
     TC(name='max', size=[10 ** 7]),
-    TC(name='median', size=[10 ** 7]),
     TC(name='min', size=[10 ** 7]),
     TC(name='quantile', size=[10 ** 7], params='0.2'),
     TC(name='skew', size=[10 ** 7]),


### PR DESCRIPTION
Current performance:

name | nthreads | type | size | median
-- | -- | -- | -- | --
Series.rolling.median | 1 | Python | 100000 | 0.263
Series.rolling.median | 1 | SDC | 100000 | 0.388
Series.rolling.median | 4 | Python | 100000 | 0.266
Series.rolling.median | 4 | SDC | 100000 | 0.262

`Python 1 / SDC 1 = 0.678`
`SDC 1 / SDC 4 = 1.481`
Scalability is pretty weak, but exists.

Implementation with chunks is much slower than the current one.
```python
chunks = parallel_chunks(length)
for i in prange(len(chunks)):
    chunk = chunks[i]
    for idx in range(chunk.start, chunk.stop):
        finite_arr = win_finite_arr(input_arr, i, win)
        if len(finite_arr) < minp:
            output_arr[i] = numpy.nan
        else:
            output_arr[i] = rolling_func(finite_arr)
```


name | nthreads | type | size | median
-- | -- | -- | -- | --
Series.rolling.median | 1 | Python | 100000 | 0.339
Series.rolling.median | 1 | SDC | 100000 | 1.32
Series.rolling.median | 4 | Python | 100000 | 0.3
Series.rolling.median | 4 | SDC | 100000 | 5.2

`Python 1 / SDC 1 = 0.257`
`SDC 1 / SDC 4 = 0.254`
There is no scalability at all.
