### PR TITLE
Optimize series.rolling.kurt()

### DIFF
--- a/sdc/tests/tests_perf/test_perf_series_rolling.py
+++ b/sdc/tests/tests_perf/test_perf_series_rolling.py
@@ -85,6 +85,7 @@ class TestSeriesRollingMethods(TestBase):
     def setUpClass(cls):
         super().setUpClass()
         cls.map_ncalls_dlength = {
+            'kurt': (100, [8 * 10 ** 5]),
             'mean': (100, [8 * 10 ** 5]),
             'sum': (100, [8 * 10 ** 5]),
         }
@@ -125,6 +126,9 @@ class TestSeriesRollingMethods(TestBase):
             data_num += len(extra_usecase_params.split(', '))
         self._test_case(usecase, name, total_data_length, data_num=data_num)
 
+    def test_series_rolling_kurt(self):
+        self._test_series_rolling_method('kurt')
+
     def test_series_rolling_mean(self):
         self._test_series_rolling_method('mean')
 
@@ -137,7 +141,6 @@ cases = [
     TC(name='corr', size=[10 ** 7]),
     TC(name='count', size=[10 ** 7]),
     TC(name='cov', size=[10 ** 7]),
-    TC(name='kurt', size=[10 ** 7]),
     TC(name='max', size=[10 ** 7]),
     TC(name='median', size=[10 ** 7]),
     TC(name='min', size=[10 ** 7]),


### PR DESCRIPTION
Result of current (multi-thread) implementation:

name | nthreads | type | size | median
-- | -- | -- | -- | --
Series.rolling.kurt | 1 | Python | 800000 | 4.329
Series.rolling.kurt | 1 | SDC | 800000 | 0.467
Series.rolling.kurt | 4 | Python | 800000 | 4.360
Series.rolling.kurt | 4 | SDC | 800000 | 0.248

`Python 1 / SDC 1 = 9.27`
`SDC 1 / SDC 4 = 1.883`

Just in case result of previous (non-optimal) implementation:

name | nthreads | type | size | median
-- | -- | -- | -- | --
Series.rolling.kurt | 1 | Python | 800000 | 4.567
Series.rolling.kurt | 1 | SDC | 800000 | 30.099

`Python 1 / SDC 1 = 0.158`
`SDC 1 / OPT_SDC 1 = 64.452`
`SDC 1 / OPT_SDC 4 = 121.367`