### PR TITLE
Optimize series.rolling.skew()

### DIFF
--- a/sdc/datatypes/hpat_pandas_series_rolling_functions.py
+++ b/sdc/datatypes/hpat_pandas_series_rolling_functions.py
@@ -185,31 +185,6 @@ def arr_quantile(arr, q):
 
 
 @sdc_register_jitable
-def _moment(arr, moment):
-    mn = numpy.mean(arr)
-    s = numpy.power((arr - mn), moment)
-
-    return numpy.mean(s)
-
-
-@sdc_register_jitable
-def arr_skew(arr):
-    """Calculate unbiased skewness of values"""
-    n = len(arr)
-    if n < 3:
-        return numpy.nan
-
-    m2 = _moment(arr, 2)
-    m3 = _moment(arr, 3)
-    val = 0 if m2 == 0 else m3 / m2 ** 1.5
-
-    if (n > 2) & (m2 > 0):
-        val = numpy.sqrt((n - 1.0) * n) / (n - 2.0) * m3 / m2 ** 1.5
-
-    return val
-
-
-@sdc_register_jitable
 def arr_std(arr, ddof):
     """Calculate standard deviation of values"""
     return arr_var(arr, ddof) ** 0.5
@@ -297,12 +272,36 @@ hpat_pandas_rolling_series_median_impl = register_jitable(
     gen_hpat_pandas_series_rolling_impl(arr_median))
 hpat_pandas_rolling_series_min_impl = register_jitable(
     gen_hpat_pandas_series_rolling_impl(arr_min))
-hpat_pandas_rolling_series_skew_impl = register_jitable(
-    gen_hpat_pandas_series_rolling_impl(arr_skew))
 hpat_pandas_rolling_series_std_impl = register_jitable(
     gen_hpat_pandas_series_rolling_ddof_impl(arr_std))
 hpat_pandas_rolling_series_var_impl = register_jitable(
     gen_hpat_pandas_series_rolling_ddof_impl(arr_var))
+
+
+@sdc_register_jitable
+def put_skew(value, nfinite, result):
+    """Calculate the window sums for skew with new value."""
+    _sum, square_sum, cube_sum = result
+    if numpy.isfinite(value):
+        nfinite += 1
+        _sum += value
+        square_sum += value * value
+        cube_sum += value * value * value
+
+    return nfinite, (_sum, square_sum, cube_sum)
+
+
+@sdc_register_jitable
+def pop_skew(value, nfinite, result):
+    """Calculate the window sums for skew without old value."""
+    _sum, square_sum, cube_sum = result
+    if numpy.isfinite(value):
+        nfinite -= 1
+        _sum -= value
+        square_sum -= value * value
+        cube_sum -= value * value * value
+
+    return nfinite, (_sum, square_sum, cube_sum)
 
 
 @sdc_register_jitable
@@ -341,6 +340,25 @@ def mean_result_or_nan(nfinite, minp, result):
         return numpy.nan
 
     return result / nfinite
+
+
+@sdc_register_jitable
+def skew_result_or_nan(nfinite, minp, result):
+    """Get result skew taking into account min periods."""
+    if nfinite < max(3, minp):
+        return numpy.nan
+
+    _sum, square_sum, cube_sum = result
+
+    n = nfinite
+    m2 = (square_sum - _sum * _sum / n) / n
+    m3 = (cube_sum - 3.*_sum*square_sum/n + 2.*_sum*_sum*_sum/n/n) / n
+    res = 0 if m2 == 0 else m3 / m2 ** 1.5
+
+    if (n > 2) & (m2 > 0):
+        res = numpy.sqrt((n - 1.) * n) / (n - 2.) * m3 / m2 ** 1.5
+
+    return res
 
 
 def gen_sdc_pandas_series_rolling_impl(pop, put, get_result=result_or_nan,
@@ -390,6 +408,8 @@ def gen_sdc_pandas_series_rolling_impl(pop, put, get_result=result_or_nan,
 
 sdc_pandas_series_rolling_mean_impl = gen_sdc_pandas_series_rolling_impl(
     pop_sum, put_sum, get_result=mean_result_or_nan, init_result=0.)
+sdc_pandas_series_rolling_skew_impl = gen_sdc_pandas_series_rolling_impl(
+    pop_skew, put_skew, get_result=skew_result_or_nan, init_result=(0., 0., 0.))
 sdc_pandas_series_rolling_sum_impl = gen_sdc_pandas_series_rolling_impl(
     pop_sum, put_sum, init_result=0.)
 
@@ -701,13 +721,13 @@ def hpat_pandas_series_rolling_quantile(self, quantile, interpolation='linear'):
     return hpat_pandas_rolling_series_quantile_impl
 
 
-@sdc_rolling_overload(SeriesRollingType, 'skew')
+@sdc_overload_method(SeriesRollingType, 'skew')
 def hpat_pandas_series_rolling_skew(self):
 
     ty_checker = TypeChecker('Method rolling.skew().')
     ty_checker.check(self, SeriesRollingType)
 
-    return hpat_pandas_rolling_series_skew_impl
+    return sdc_pandas_series_rolling_skew_impl
 
 
 @sdc_rolling_overload(SeriesRollingType, 'std')

--- a/sdc/tests/tests_perf/test_perf_series_rolling.py
+++ b/sdc/tests/tests_perf/test_perf_series_rolling.py
@@ -86,6 +86,7 @@ class TestSeriesRollingMethods(TestBase):
         super().setUpClass()
         cls.map_ncalls_dlength = {
             'mean': (100, [8 * 10 ** 5]),
+            'skew': (100, [8 * 10 ** 5]),
             'sum': (100, [8 * 10 ** 5]),
         }
 
@@ -128,6 +129,9 @@ class TestSeriesRollingMethods(TestBase):
     def test_series_rolling_mean(self):
         self._test_series_rolling_method('mean')
 
+    def test_series_rolling_skew(self):
+        self._test_series_rolling_method('skew')
+
     def test_series_rolling_sum(self):
         self._test_series_rolling_method('sum')
 
@@ -142,7 +146,6 @@ cases = [
     TC(name='median', size=[10 ** 7]),
     TC(name='min', size=[10 ** 7]),
     TC(name='quantile', size=[10 ** 7], params='0.2'),
-    TC(name='skew', size=[10 ** 7]),
     TC(name='std', size=[10 ** 7]),
     TC(name='var', size=[10 ** 7]),
 ]


### PR DESCRIPTION
Result of current (multi-thread) implementation:

name | nthreads | type | size | median
-- | -- | -- | -- | --
Series.rolling.skew | 1 | Python | 800000 | 5.624
Series.rolling.skew | 1 | SDC | 800000 | 0.479
Series.rolling.skew | 4 | Python | 800000 | 4.794
Series.rolling.skew | 4 | SDC | 800000 | 0.265

`Python 1 / SDC 1 = 11.741`
`SDC 1 / SDC 4 = 1.808`

Just in case result of previous (non-optimal) implementation:

name | nthreads | type | size | median
-- | -- | -- | -- | --
Series.rolling.skew | 1 | Python | 800000 | 4.945
Series.rolling.skew | 1 | SDC | 800000 | 32.357

`Python 1 / SDC 1 = 0.153`
`SDC 1 / OPT_SDC 1 = 67.551`
`SDC 1 / OPT_SDC 4 = 122.102`

