### PR TITLE
Disable perf tests for Python if NUMBA_NUM_THREADS > 1

### DIFF
--- a/sdc/tests/tests_perf/test_perf_base.py
+++ b/sdc/tests/tests_perf/test_perf_base.py
@@ -60,6 +60,10 @@ class TestBase(TestCase):
         self.test_results.add(**record)
 
     def _test_py(self, pyfunc, base, *args):
+        skip = 'NUMBA_NUM_THREADS' in os.environ and config.NUMBA_NUM_THREADS > 1
+        if skip:
+            return
+
         record = base.copy()
         record["test_type"] = 'Python'
         self._test_python(pyfunc, record, *args)


### PR DESCRIPTION
This PR make running perf tests for Python only when threads count is 1 or NUMBA_NUM_THREADS is not set. It is not necessary to run Python tests with 2 or more NUMBA_NUM_THREADS b/c Python code does not scale.