### PR TITLE
Scale getitem by Boolean mask (array or Series) for Series and DFs

### DIFF
--- a/sdc/datatypes/common_functions.py
+++ b/sdc/datatypes/common_functions.py
@@ -32,6 +32,7 @@
 
 import numpy
 import pandas
+from pandas.core.indexing import IndexingError
 
 import numba
 from numba.targets import quicksort
@@ -39,6 +40,7 @@ from numba import types
 from numba.errors import TypingError
 from numba.extending import register_jitable
 from numba import numpy_support
+from numba.typed import Dict
 
 import sdc
 from sdc.hiframes.api import isna
@@ -46,7 +48,8 @@ from sdc.hiframes.pd_series_type import SeriesType
 from sdc.str_arr_type import string_array_type
 from sdc.str_arr_ext import (num_total_chars, append_string_array_to,
                              str_arr_is_na, pre_alloc_string_array, str_arr_set_na, string_array_type,
-                             cp_str_list_to_array, create_str_arr_from_list, get_utf8_size)
+                             cp_str_list_to_array, create_str_arr_from_list, get_utf8_size,
+                             str_arr_set_na_by_mask)
 from sdc.utilities.prange_utils import parallel_chunks
 from sdc.utilities.utils import sdc_overload, sdc_register_jitable
 from sdc.utilities.sdc_typing_utils import (find_common_dtype_from_numpy_dtypes,
@@ -641,3 +644,59 @@ def _almost_equal_overload(x, y):
         return abs(x - y) <= numpy.finfo(common_dtype).eps
 
     return _almost_equal_impl
+
+
+def sdc_reindex_series(arr, index, name, by_index):
+    pass
+
+
+@sdc_overload(sdc_reindex_series, jit_options={'parallel': True})
+def sdc_reindex_series_overload(arr, index, name, by_index):
+    """ Reindexes series data by new index following the logic of pandas.core.indexing.check_bool_indexer """
+
+    data_dtype, index_dtype = arr.dtype, index.dtype
+    data_is_str_arr = isinstance(arr.dtype, types.UnicodeType)
+
+    def sdc_reindex_series_impl(arr, index, name, by_index):
+        res_index = by_index.copy()
+        if data_is_str_arr == True:  # noqa
+            res_data_as_list = [''] * len(by_index)
+            res_data_nan_mask = numpy.zeros(len(by_index), dtype=types.bool_)
+        else:
+            res_data = numpy.empty(len(by_index), dtype=data_dtype)
+
+        # build a dict of self.index values to their positions:
+        map_index_to_position = Dict.empty(
+            key_type=index_dtype,
+            value_type=types.int32
+        )
+
+        for i, value in enumerate(index):
+            if value in map_index_to_position:
+                raise ValueError("cannot reindex from a duplicate axis")
+            else:
+                map_index_to_position[value] = i
+
+        index_mismatch = 0
+        for i in numba.prange(len(by_index)):
+            if by_index[i] in map_index_to_position:
+                pos_in_self = map_index_to_position[by_index[i]]
+                res_data[i] = arr[pos_in_self]
+                if data_is_str_arr == True:  # noqa
+                    res_data_nan_mask[i] = isna(arr, i)
+            else:
+                index_mismatch += 1
+        if index_mismatch:
+            msg = "Unalignable boolean Series provided as indexer " + \
+                  "(index of the boolean Series and of the indexed object do not match)."
+            raise IndexingError(msg)
+
+        if data_is_str_arr == True:  # noqa
+            res_data = create_str_arr_from_list(res_data_as_list)
+            str_arr_set_na_by_mask(res_data, res_data_nan_mask)
+
+        return pandas.Series(data=res_data, index=res_index, name=name)
+
+    return sdc_reindex_series_impl
+
+    return None

--- a/sdc/datatypes/hpat_pandas_dataframe_functions.py
+++ b/sdc/datatypes/hpat_pandas_dataframe_functions.py
@@ -1314,15 +1314,14 @@ def df_getitem_bool_series_idx_main_codelines(self, idx):
 
     # optimization for default indexes in df and idx when index alignment is trivial
     if (isinstance(self.index, types.NoneType) and isinstance(idx.index, types.NoneType)):
-        func_lines = ['  lenght = {df_length_expr(self)}']
-        func_lines += ['  if length > len(idx):']
-        func_lines += ['    msg = "Unalignable boolean Series provided as indexer " + \\']
-        func_lines += ['          "(index of the boolean Series and of the indexed object do not match)."']
-        func_lines += ['    raise IndexingError(msg)']
-        func_lines += ['  # do not trim idx._data to length as getitem_by_mask handles such case']
-        func_lines += ['  res_index = getitem_by_mask(self.index, idx._data)']
-
-        func_lines += ['  # df index is default, same as positions so it can be used in take']
+        func_lines = [f'  length = {df_length_expr(self)}',
+                      f'  if length > len(idx):',
+                      f'    msg = "Unalignable boolean Series provided as indexer " + \\',
+                      f'          "(index of the boolean Series and of the indexed object do not match)."',
+                      f'    raise IndexingError(msg)',
+                      f'  # do not trim idx._data to length as getitem_by_mask handles such case',
+                      f'  res_index = getitem_by_mask(self.index, idx._data)',
+                      f'  # df index is default, same as positions so it can be used in take']
         results = []
         for i, col in enumerate(self.columns):
             res_data = f'res_data_{i}'
@@ -1337,11 +1336,11 @@ def df_getitem_bool_series_idx_main_codelines(self, idx):
             f'  return pandas.DataFrame({{{data}}}, index=res_index)'
         ]
     else:
-        func_lines = ['  lenght = {df_length_expr(self)}']
-        func_lines += ['  self_index = self.index']
-        func_lines += ['  idx_reindexed = sdc_reindex_series(idx._data, idx.index, idx._name, self_index)']
-        func_lines += ['  res_index = getitem_by_mask(self_index, idx_reindexed._data)']
-        func_lines += ['  selected_pos = getitem_by_mask(numpy.arange(length), idx_reindexed._data)']
+        func_lines = [f'  length = {df_length_expr(self)}',
+                      f'  self_index = self.index',
+                      f'  idx_reindexed = sdc_reindex_series(idx._data, idx.index, idx._name, self_index)',
+                      f'  res_index = getitem_by_mask(self_index, idx_reindexed._data)',
+                      f'  selected_pos = getitem_by_mask(numpy.arange(length), idx_reindexed._data)']
 
         results = []
         for i, col in enumerate(self.columns):
@@ -1362,10 +1361,10 @@ def df_getitem_bool_series_idx_main_codelines(self, idx):
 
 def df_getitem_bool_array_idx_main_codelines(self, idx):
     """Generate main code lines for df.getitem"""
-    func_lines = ['  lenght = {df_length_expr(self)}']
-    func_lines += ['  if length != len(idx):',
-                   '    raise ValueError("Item wrong length.")']
-    func_lines += ['  res_index = getitem_by_mask(self.index, idx)']
+    func_lines = [f'  length = {df_length_expr(self)}',
+                  f'  if length != len(idx):',
+                  f'    raise ValueError("Item wrong length.")',
+                  f'  res_index = getitem_by_mask(self.index, idx)']
     results = []
     for i, col in enumerate(self.columns):
         res_data = f'res_data_{i}'
@@ -1495,13 +1494,13 @@ def df_getitem_bool_array_idx_codegen(self, idx):
     return func_text, global_vars
 
 
-gen_df_getitem_slice_idx_impl = gen_df_impl_generator(
+gen_df_getitem_slice_idx_impl = gen_impl_generator(
     df_getitem_slice_idx_codegen, '_df_getitem_slice_idx_impl')
-gen_df_getitem_tuple_idx_impl = gen_df_impl_generator(
+gen_df_getitem_tuple_idx_impl = gen_impl_generator(
     df_getitem_tuple_idx_codegen, '_df_getitem_tuple_idx_impl')
-gen_df_getitem_bool_series_idx_impl = gen_df_impl_generator(
+gen_df_getitem_bool_series_idx_impl = gen_impl_generator(
     df_getitem_bool_series_idx_codegen, '_df_getitem_bool_series_idx_impl')
-gen_df_getitem_bool_array_idx_impl = gen_df_impl_generator(
+gen_df_getitem_bool_array_idx_impl = gen_impl_generator(
     df_getitem_bool_array_idx_codegen, '_df_getitem_bool_array_idx_impl')
 
 

--- a/sdc/datatypes/hpat_pandas_dataframe_functions.py
+++ b/sdc/datatypes/hpat_pandas_dataframe_functions.py
@@ -1364,13 +1364,14 @@ def df_getitem_bool_array_idx_main_codelines(self, idx):
     func_lines = [f'  length = {df_length_expr(self)}',
                   f'  if length != len(idx):',
                   f'    raise ValueError("Item wrong length.")',
-                  f'  res_index = getitem_by_mask(self.index, idx)']
+                  f'  taken_pos = getitem_by_mask(numpy.arange(length), idx)',
+                  f'  res_index = sdc_take(self.index, taken_pos)']
     results = []
     for i, col in enumerate(self.columns):
         res_data = f'res_data_{i}'
         func_lines += [
             f'  data_{i} = get_dataframe_data(self, {i})',
-            f'  {res_data} = getitem_by_mask(data_{i}, idx)'
+            f'  {res_data} = sdc_take(data_{i}, taken_pos)'
         ]
         results.append((col, res_data))
 
@@ -1477,11 +1478,12 @@ def df_getitem_bool_array_idx_codegen(self, idx):
           length = len(get_dataframe_data(self, 0))
           if length != len(idx):
             raise ValueError("Item wrong length.")
-          res_index = getitem_by_mask(self.index, idx)
+          taken_pos = getitem_by_mask(numpy.arange(length), idx)
+          res_index = sdc_take(self.index, taken_pos)
           data_0 = get_dataframe_data(self, 0)
-          res_data_0 = getitem_by_mask(data_0, idx)
+          res_data_0 = sdc_take(data_0, taken_pos)
           data_1 = get_dataframe_data(self, 1)
-          res_data_1 = getitem_by_mask(data_1, idx)
+          res_data_1 = sdc_take(data_1, taken_pos)
           return pandas.DataFrame({"A": res_data_0, "B": res_data_1}, index=res_index)
     """
     func_lines = ['def _df_getitem_bool_array_idx_impl(self, idx):']
@@ -1489,7 +1491,8 @@ def df_getitem_bool_array_idx_codegen(self, idx):
     func_text = '\n'.join(func_lines)
     global_vars = {'pandas': pandas, 'numpy': numpy,
                    'get_dataframe_data': get_dataframe_data,
-                   'getitem_by_mask': getitem_by_mask}
+                   'getitem_by_mask': getitem_by_mask,
+                   'sdc_take': _sdc_take}
 
     return func_text, global_vars
 

--- a/sdc/datatypes/hpat_pandas_dataframe_functions.py
+++ b/sdc/datatypes/hpat_pandas_dataframe_functions.py
@@ -35,10 +35,10 @@ import pandas
 import numpy
 import sdc
 
-
 from numba import types
 from numba.special import literally
 from numba.typed import List, Dict
+from pandas.core.indexing import IndexingError
 
 from sdc.hiframes.pd_dataframe_ext import DataFrameType
 from sdc.hiframes.pd_series_type import SeriesType
@@ -56,7 +56,8 @@ from sdc.datatypes.hpat_pandas_groupby_functions import init_dataframe_groupby
 from sdc.hiframes.pd_dataframe_ext import get_dataframe_data
 from sdc.utilities.utils import sdc_overload, sdc_overload_method, sdc_overload_attribute
 from sdc.hiframes.api import isna
-
+from sdc.functions.numpy_like import getitem_by_mask
+from sdc.datatypes.common_functions import _sdc_take, sdc_reindex_series
 
 @sdc_overload_attribute(DataFrameType, 'index')
 def hpat_pandas_dataframe_index(df):
@@ -1311,22 +1312,51 @@ def df_getitem_tuple_idx_main_codelines(self, literal_idx):
 
 def df_getitem_bool_series_idx_main_codelines(self, idx):
     """Generate main code lines for df.getitem"""
-    func_lines = df_length_codelines(self)
-    func_lines += ['  _idx_data = idx._data[:length]']
-    func_lines += df_index_codelines(self)
 
-    results = []
-    for i, col in enumerate(self.columns):
-        res_data = f'res_data_{i}'
+    # optimization for default indexes in df and idx when index alignment is trivial
+    if (isinstance(self.index, types.NoneType) and isinstance(idx.index, types.NoneType)):
+        func_lines = df_length_codelines(self)
+        func_lines += ['  if length > len(idx):']
+        func_lines += ['    msg = "Unalignable boolean Series provided as indexer " + \\']
+        func_lines += ['          "(index of the boolean Series and of the indexed object do not match)."']
+        func_lines += ['    raise IndexingError(msg)']
+        func_lines += ['  # do not trim idx._data to length as getitem_by_mask handles such case']
+        func_lines += ['  res_index = getitem_by_mask(self.index, idx._data)']
+
+        func_lines += ['  # df index is default, same as positions so it can be used in take']
+        results = []
+        for i, col in enumerate(self.columns):
+            res_data = f'res_data_{i}'
+            func_lines += [
+                f'  data_{i} = get_dataframe_data(self, {i})',
+                f'  {res_data} = sdc_take(data_{i}, res_index)'
+            ]
+            results.append((col, res_data))
+
+        data = ', '.join(f'"{col}": {data}' for col, data in results)
         func_lines += [
-            f'  data_{i} = get_dataframe_data(self, {i})',
-            f'  series_{i} = pandas.Series(data_{i}, index=res_index, name="{col}")',
-            f'  {res_data} = series_{i}[_idx_data]'
+            f'  return pandas.DataFrame({{{data}}}, index=res_index)'
         ]
-        results.append((col, res_data))
+    else:
+        func_lines = df_length_codelines(self)
+        func_lines += ['  self_index = self.index']
+        func_lines += ['  idx_reindexed = sdc_reindex_series(idx._data, idx.index, idx._name, self_index)']
+        func_lines += ['  res_index = getitem_by_mask(self_index, idx_reindexed._data)']
+        func_lines += ['  selected_pos = getitem_by_mask(numpy.arange(length), idx_reindexed._data)']
 
-    data = ', '.join(f'"{col}": {data}' for col, data in results)
-    func_lines += [f'  return pandas.DataFrame({{{data}}}, index=res_index[_idx_data])']
+        results = []
+        for i, col in enumerate(self.columns):
+            res_data = f'res_data_{i}'
+            func_lines += [
+                f'  data_{i} = get_dataframe_data(self, {i})',
+                f'  {res_data} = sdc_take(data_{i}, selected_pos)'
+            ]
+            results.append((col, res_data))
+
+        data = ', '.join(f'"{col}": {data}' for col, data in results)
+        func_lines += [
+            f'  return pandas.DataFrame({{{data}}}, index=res_index)'
+        ]
 
     return func_lines
 
@@ -1336,19 +1366,20 @@ def df_getitem_bool_array_idx_main_codelines(self, idx):
     func_lines = df_length_codelines(self)
     func_lines += ['  if length != len(idx):',
                    '    raise ValueError("Item wrong length.")']
-    func_lines += df_index_codelines(self)
-
+    func_lines += ['  res_index = getitem_by_mask(self.index, idx)']
     results = []
     for i, col in enumerate(self.columns):
         res_data = f'res_data_{i}'
         func_lines += [
             f'  data_{i} = get_dataframe_data(self, {i})',
-            f'  {res_data} = pandas.Series(data_{i}[idx], index=res_index[idx], name="{col}")'
+            f'  {res_data} = getitem_by_mask(data_{i}, idx)'
         ]
         results.append((col, res_data))
 
     data = ', '.join(f'"{col}": {data}' for col, data in results)
-    func_lines += [f'  return pandas.DataFrame({{{data}}}, index=res_index[idx])']
+    func_lines += [
+        f'  return pandas.DataFrame({{{data}}}, index=res_index)'
+    ]
 
     return func_lines
 
@@ -1415,21 +1446,28 @@ def df_getitem_bool_series_idx_codegen(self, idx):
     Example of generated implementation with provided index:
         def _df_getitem_bool_series_idx_impl(self, idx):
           length = len(get_dataframe_data(self, 0))
-          _idx_data = idx._data[:length]
-          res_index = self._index
+          if length > len(idx):
+            msg = "Unalignable boolean Series provided as indexer " + \
+                  "(index of the boolean Series and of the indexed object do not match)."
+            raise IndexingError(msg)
+          # do not trim idx._data to length as getitem_by_mask handles such case
+          res_index = getitem_by_mask(self.index, idx._data)
+          # df index is default, same as positions so it can be used in take
           data_0 = get_dataframe_data(self, 0)
-          series_0 = pandas.Series(data_0, index=res_index, name="A")
-          res_data_0 = series_0[_idx_data]
+          res_data_0 = sdc_take(data_0, res_index)
           data_1 = get_dataframe_data(self, 1)
-          series_1 = pandas.Series(data_1, index=res_index, name="B")
-          res_data_1 = series_1[_idx_data]
-          return pandas.DataFrame({"A": res_data_0, "B": res_data_1}, index=res_index[_idx_data])
+          res_data_1 = sdc_take(data_1, res_index)
+          return pandas.DataFrame({"A": res_data_0, "B": res_data_1}, index=res_index)
     """
     func_lines = ['def _df_getitem_bool_series_idx_impl(self, idx):']
     func_lines += df_getitem_bool_series_idx_main_codelines(self, idx)
     func_text = '\n'.join(func_lines)
     global_vars = {'pandas': pandas, 'numpy': numpy,
-                   'get_dataframe_data': get_dataframe_data}
+                   'get_dataframe_data': get_dataframe_data,
+                   'getitem_by_mask': getitem_by_mask,
+                   'sdc_take': _sdc_take,
+                   'sdc_reindex_series': sdc_reindex_series,
+                   'IndexingError': IndexingError}
 
     return func_text, global_vars
 
@@ -1441,18 +1479,19 @@ def df_getitem_bool_array_idx_codegen(self, idx):
           length = len(get_dataframe_data(self, 0))
           if length != len(idx):
             raise ValueError("Item wrong length.")
-          res_index = numpy.arange(length)
+          res_index = getitem_by_mask(self.index, idx)
           data_0 = get_dataframe_data(self, 0)
-          res_data_0 = pandas.Series(data_0[idx], index=res_index[idx], name="A")
+          res_data_0 = getitem_by_mask(data_0, idx)
           data_1 = get_dataframe_data(self, 1)
-          res_data_1 = pandas.Series(data_1[idx], index=res_index[idx], name="B")
-          return pandas.DataFrame({"A": res_data_0, "B": res_data_1}, index=res_index[idx])
+          res_data_1 = getitem_by_mask(data_1, idx)
+          return pandas.DataFrame({"A": res_data_0, "B": res_data_1}, index=res_index)
     """
     func_lines = ['def _df_getitem_bool_array_idx_impl(self, idx):']
     func_lines += df_getitem_bool_array_idx_main_codelines(self, idx)
     func_text = '\n'.join(func_lines)
     global_vars = {'pandas': pandas, 'numpy': numpy,
-                   'get_dataframe_data': get_dataframe_data}
+                   'get_dataframe_data': get_dataframe_data,
+                   'getitem_by_mask': getitem_by_mask}
 
     return func_text, global_vars
 

--- a/sdc/datatypes/hpat_pandas_series_functions.py
+++ b/sdc/datatypes/hpat_pandas_series_functions.py
@@ -43,13 +43,15 @@ from numba import (types, numpy_support, cgutils)
 from numba.typed import List, Dict
 from numba import prange
 from numba.targets.arraymath import get_isnan
+from pandas.core.indexing import IndexingError
 
 import sdc
 import sdc.datatypes.common_functions as common_functions
 from sdc.utilities.sdc_typing_utils import (TypeChecker, check_index_is_numeric, check_types_comparable,
                                             find_common_dtype_from_numpy_dtypes, has_literal_value,
                                             has_python_value)
-from sdc.datatypes.common_functions import (sdc_join_series_indexes, sdc_arrays_argsort, sdc_check_indexes_equal)
+from sdc.datatypes.common_functions import (sdc_join_series_indexes, sdc_arrays_argsort, sdc_check_indexes_equal,
+                                            sdc_reindex_series)
 from sdc.datatypes.hpat_pandas_rolling_types import (
     gen_sdc_pandas_rolling_overload_body, sdc_pandas_rolling_docstring_tmpl)
 from sdc.datatypes.hpat_pandas_series_rolling_types import _hpat_pandas_series_rolling_init
@@ -326,7 +328,7 @@ def hpat_pandas_series_getitem(self, idx):
     Pandas Series operator :attr:`pandas.Series.__getitem__` implementation
 
     .. only:: developer
-        Test: python -m sdc.runtests -k sdc.tests.test_series.TestSeries.test_getitem_series*
+        Test: python -m sdc.runtests -k sdc.tests.test_series.TestSeries.test_series_getitem*
     """
 
     _func_name = 'Operator getitem().'
@@ -365,23 +367,60 @@ def hpat_pandas_series_getitem(self, idx):
 
         return hpat_pandas_series_getitem_idx_slice_impl
 
-    if (
-        isinstance(idx, (types.List, types.Array)) and
-        isinstance(idx.dtype, (types.Boolean, bool))
-    ):
+    if (isinstance(idx, (types.List, types.Array))
+            and isinstance(idx.dtype, (types.Boolean, bool))):
         def hpat_pandas_series_getitem_idx_list_impl(self, idx):
-            return pandas.Series(data=self._data[idx], index=self.index[idx], name=self._name)
+
+            if len(self) != len(idx):
+                raise IndexError("Item wrong length")
+
+            return pandas.Series(
+                data=numpy_like.getitem_by_mask(self._data, idx),
+                index=numpy_like.getitem_by_mask(self.index, idx),
+                name=self._name
+            )
+
         return hpat_pandas_series_getitem_idx_list_impl
 
-    if (index_is_none and isinstance(idx, SeriesType)):
-        if isinstance(idx.data.dtype, (types.Boolean, bool)):
-            def hpat_pandas_series_getitem_idx_list_impl(self, idx):
-                index = numpy.arange(len(self._data))
-                if (index != idx.index).sum() == 0:
-                    return pandas.Series(data=self._data[idx._data], index=index[idx._data], name=self._name)
+    # idx is Series and it's index is any, idx.dtype is Boolean
+    if (isinstance(idx, SeriesType) and isinstance(idx.dtype, types.Boolean)):
 
-            return hpat_pandas_series_getitem_idx_list_impl
+        none_indexes = isinstance(self.index, types.NoneType) and isinstance(idx.index, types.NoneType)
+        none_or_numeric_indexes = ((isinstance(self.index, types.NoneType) or check_index_is_numeric(self))
+                                   and (isinstance(idx.index, types.NoneType) or check_index_is_numeric(idx)))
+        if not (none_or_numeric_indexes
+                or check_types_comparable(self.index, idx.index)):
+            msg = '{} The index of boolean indexer is not comparable to Series index.' + \
+                  ' Given: self.index={}, idx.index={}'
+            raise TypingError(msg.format(_func_name, self.index, idx.index))
 
+        def hpat_pandas_series_getitem_idx_bool_indexer_impl(self, idx):
+
+            if none_indexes == True:  # noqa
+                if len(self) > len(idx):
+                    msg = "Unalignable boolean Series provided as indexer " + \
+                          "(index of the boolean Series and of the indexed object do not match)."
+                    raise IndexingError(msg)
+
+                return pandas.Series(
+                    data=numpy_like.getitem_by_mask(self._data, idx._data),
+                    index=numpy_like.getitem_by_mask(self.index, idx._data),
+                    name=self._name
+                )
+            else:
+                self_index = self.index
+                idx_reindexed = sdc_reindex_series(idx._data, idx.index, idx._name, self_index)
+                return pandas.Series(
+                    data=numpy_like.getitem_by_mask(self._data, idx_reindexed._data),
+                    index=numpy_like.getitem_by_mask(self_index, idx_reindexed._data),
+                    name=self._name
+                )
+
+        return hpat_pandas_series_getitem_idx_bool_indexer_impl
+
+    # idx is Series and it's index is None, idx.dtype is not Boolean
+    if (isinstance(idx, SeriesType) and index_is_none
+            and not isinstance(idx.data.dtype, (types.Boolean, bool))):
         def hpat_pandas_series_getitem_idx_list_impl(self, idx):
             res = numpy.copy(self._data[:len(idx._data)])
             index = numpy.arange(len(self._data))
@@ -392,15 +431,9 @@ def hpat_pandas_series_getitem(self, idx):
             return pandas.Series(data=res, index=index[idx._data], name=self._name)
         return hpat_pandas_series_getitem_idx_list_impl
 
-    if (isinstance(idx, SeriesType) and not isinstance(self.index, types.NoneType)):
-        if isinstance(idx.data.dtype, (types.Boolean, bool)):
-            # Series with str index not implement
-            def hpat_pandas_series_getitem_idx_series_impl(self, idx):
-                if (self._index != idx._index).sum() == 0:
-                    return pandas.Series(data=self._data[idx._data], index=self._index[idx._data], name=self._name)
-
-            return hpat_pandas_series_getitem_idx_series_impl
-
+    # idx is Series and it's index is not None, idx.dtype is not Boolean
+    if (isinstance(idx, SeriesType) and not isinstance(self.index, types.NoneType)
+            and not isinstance(idx.data.dtype, (types.Boolean, bool))):
         def hpat_pandas_series_getitem_idx_series_impl(self, idx):
             index = self.index
             data = self._data
@@ -418,6 +451,7 @@ def hpat_pandas_series_getitem(self, idx):
             return pandas.Series(data=data_res, index=index_res, name=self._name)
 
         return hpat_pandas_series_getitem_idx_series_impl
+
 
     raise TypingError('{} The index must be an Number, Slice, String, Boolean Array or a Series.\
                     Given: {}'.format(_func_name, idx))
@@ -3354,7 +3388,7 @@ def hpat_pandas_series_quantile(self, q=0.5, interpolation='linear'):
     ty_checker = TypeChecker(_func_name)
     ty_checker.check(self, SeriesType)
 
-    if not isinstance(interpolation, types.Omitted) and interpolation is not 'linear':
+    if not isinstance(interpolation, types.Omitted) and interpolation != 'linear':
         ty_checker.raise_exc(interpolation, 'str', 'interpolation')
 
     if not isinstance(q, (int, float, list, types.Number, types.Omitted, types.List)):

--- a/sdc/functions/numpy_like.py
+++ b/sdc/functions/numpy_like.py
@@ -47,8 +47,8 @@ from sdc.utilities.sdc_typing_utils import TypeChecker
 from sdc.utilities.utils import (sdc_overload, sdc_register_jitable,
                                  min_dtype_int_val, max_dtype_int_val, min_dtype_float_val,
                                  max_dtype_float_val)
-from sdc.str_arr_ext import (StringArrayType, pre_alloc_string_array, get_utf8_size, str_arr_is_na,
-    string_array_type, create_str_arr_from_list, str_arr_set_na_by_mask)
+from sdc.str_arr_ext import (StringArrayType, pre_alloc_string_array, get_utf8_size,
+                             string_array_type, create_str_arr_from_list, str_arr_set_na_by_mask)
 from sdc.utilities.utils import sdc_overload, sdc_register_jitable
 from sdc.utilities.prange_utils import parallel_chunks
 

--- a/sdc/tests/test_dataframe.py
+++ b/sdc/tests/test_dataframe.py
@@ -1461,7 +1461,6 @@ class TestDataFrame(TestCase):
                     sdc_func(df, arr)
                 self.assertIn('Item wrong length', str(raises.exception))
 
-
     @skip_sdc_jit('DF.getitem unsupported Series name')
     def test_df_getitem_idx(self):
         dfs = [gen_df(test_global_input_data_float64),
@@ -1500,7 +1499,6 @@ class TestDataFrame(TestCase):
                 self._test_df_getitem_bool_series_even_idx(df)
                 self._test_df_getitem_bool_array_even_idx(df)
 
-    @unittest.skip('DF.getitem df[bool_series] unsupported index')
     def test_df_getitem_bool_series_even_idx_with_index(self):
         df = gen_df(test_global_input_data_float64, with_index=True)
         self._test_df_getitem_bool_series_even_idx(df)

--- a/sdc/tests/test_series.py
+++ b/sdc/tests/test_series.py
@@ -1046,36 +1046,6 @@ class TestSeries(
         pd.testing.assert_series_equal(hpat_func(S), test_impl(S))
 
     @skip_sdc_jit('Not impl in old style')
-    def test_series_getitem_idx_bool_arr(self):
-        def test_impl(A, B):
-            return A[B]
-        hpat_func = self.jit(test_impl)
-
-        S = pd.Series([1, 2, 3, 4], [6, 7, 8, 9], name='A')
-        n = np.array([True, False, False, True])
-        pd.testing.assert_series_equal(hpat_func(S, n), test_impl(S, n))
-
-    @skip_sdc_jit('Not impl in old style')
-    def test_series_getitem_idx_bool_series1(self):
-        def test_impl(A, B):
-            return A[B]
-        hpat_func = self.jit(test_impl)
-
-        S = pd.Series([2, 3, 1, 5], [11, 2, 44, 5], name='A')
-        S2 = pd.Series([True, False, False, True], [11, 2, 44, 5])
-        pd.testing.assert_series_equal(hpat_func(S, S2), test_impl(S, S2))
-
-    @skip_sdc_jit('Not impl in old style')
-    def test_series_getitem_idx_bool_series2(self):
-        def test_impl(A, B):
-            return A[B]
-        hpat_func = self.jit(test_impl)
-
-        S = pd.Series([2, 3, 1, 5], name='A')
-        S2 = pd.Series([True, False, False, True])
-        pd.testing.assert_series_equal(hpat_func(S, S2), test_impl(S, S2))
-
-    @skip_sdc_jit('Not impl in old style')
     def test_series_getitem_idx_series(self):
         def test_impl(A, B):
             return A[B]
@@ -6306,7 +6276,7 @@ class TestSeries(
 
         for series_data in all_data:
             for series_index in indexes:
-                S = pd.Series(series_data, series_index, dtype=dtype)
+                S = pd.Series(series_data, series_index, dtype=dtype, name='A')
                 for idx, value in product(idxs, values):
                     with self.subTest(series=S, idx=idx, value=value):
                         S1 = S.copy(deep=True)
@@ -6750,6 +6720,242 @@ class TestSeries(
                             pd.Series(assigned_values, index=values_index)
         ]
         self._test_series_setitem([series_data], [series_index], [idx], values_to_test, dtype=np.float)
+
+    def _test_series_getitem(self, all_data, indexes, idxs, dtype=None):
+        """ Common function used by getitem tests to compile and run getitem on provided data"""
+        def test_impl(A, idx):
+            return A[idx]
+        hpat_func = self.jit(test_impl)
+
+        for series_data in all_data:
+            for series_index in indexes:
+                S = pd.Series(series_data, series_index, dtype=dtype, name='A')
+                for idx in idxs:
+                    with self.subTest(series=S, idx=idx):
+                        result = hpat_func(S, idx)
+                        result_ref = test_impl(S, idx)
+                        pd.testing.assert_series_equal(result, result_ref)
+
+    @skip_sdc_jit('Not implemented in old-pipeline')
+    def test_series_getitem_idx_bool_array1(self):
+        """ Verifies Series.getitem by mask indicated by a Boolean array on Series of various dtypes and indexes """
+
+        n = 11
+        np.random.seed(0)
+        data_to_test = [
+            np.arange(n),
+            np.arange(n, dtype='float'),
+            np.random.choice([True, False], n),
+            gen_strlist(n, 2, 'abcd123 ')
+        ]
+        idxs_to_test = [
+            None,
+            np.arange(n),
+            np.arange(n, dtype='float'),
+            gen_strlist(n, 2, 'abcd123 ')
+        ]
+
+        idx = np.random.choice([True, False], n)
+        self._test_series_getitem(data_to_test, idxs_to_test, [idx])
+
+    @skip_sdc_jit('Not implemented in old-pipeline')
+    def test_series_getitem_idx_bool_array2(self):
+        """ Verifies negative case of using Series.getitem by Boolean array indexer
+        on a Series with different length than the indexer """
+        def test_impl(A, idx):
+            return A[idx]
+        hpat_func = self.jit(test_impl)
+
+        n = 11
+        np.random.seed(0)
+        S = pd.Series(np.arange(n))
+        idxs_to_test = [
+            np.random.choice([True, False], n - 3),
+            np.random.choice([True, False], n + 3)
+        ]
+
+        for idx in idxs_to_test:
+            with self.subTest(idx=idx):
+                with self.assertRaises(Exception) as context:
+                    test_impl(S, idx)
+                pandas_exception = context.exception
+
+                with self.assertRaises(type(pandas_exception)) as context:
+                    hpat_func(S, idx)
+                sdc_exception = context.exception
+                self.assertIn(str(sdc_exception), str(pandas_exception))
+
+    @skip_sdc_jit('Not implemented in old-pipeline')
+    def test_series_getitem_idx_bool_list(self):
+        """ Verifies Series.getitem by mask indicated by a Boolean list on Series of various dtypes and indexes """
+
+        n = 11
+        np.random.seed(0)
+
+        data_to_test = [
+            np.arange(n),
+            np.arange(n, dtype='float'),
+            np.random.choice([True, False], n),
+            gen_strlist(n, 2, 'abcd123 ')
+        ]
+        idxs_to_test = [
+            None,
+            np.arange(n),
+            np.arange(n, dtype='float'),
+            gen_strlist(n, 2, 'abcd123 ')
+        ]
+
+        idx = list(np.random.choice([True, False], n))
+        self._test_series_getitem(data_to_test, idxs_to_test, [idx])
+
+    @skip_sdc_jit('Not implemented in old-pipeline')
+    def test_series_getitem_idx_bool_series1(self):
+        """ Verifies Series.getitem by mask indicated by a Boolean Series on Series of various dtypes
+        when both Series and indexer have default indexes """
+
+        n, k = 21, 13
+        np.random.seed(0)
+
+        data_to_test = [
+            np.arange(n),
+            np.arange(n, dtype='float'),
+            np.random.choice([True, False], n),
+            gen_strlist(n, 2, 'abcd123 ')
+        ]
+
+        idxs_to_test = []
+        for s in (n, 2*n):
+            idx = pd.Series(np.zeros(s, dtype=np.bool), index=None)
+            idx[take_k_elements(k, np.arange(s))] = True
+            idxs_to_test.append(idx)
+
+        self._test_series_getitem(data_to_test, [None], idxs_to_test)
+
+    @skip_sdc_jit('Not implemented in old-pipeline')
+    def test_series_getitem_idx_bool_series2(self):
+        """ Verifies negative case of using Series.getitem with Boolean Series indexer idx with default index
+        on a Series with default index but wider range of index values """
+        def test_impl(A, idx):
+            return A[idx]
+        hpat_func = self.jit(test_impl)
+
+        n, k = 21, 13
+        np.random.seed(0)
+
+        S = pd.Series(np.arange(n))
+        idx = pd.Series(np.zeros(n - 3, dtype=np.bool), index=None)
+        idx[take_k_elements(k, np.arange(k))] = True
+
+        with self.assertRaises(Exception) as context:
+            test_impl(S, idx)
+        pandas_exception = context.exception
+
+        with self.assertRaises(type(pandas_exception)) as context:
+            hpat_func(S, idx)
+        sdc_exception = context.exception
+        self.assertIn(str(sdc_exception), str(pandas_exception))
+
+    @skip_sdc_jit('Not implemented in old-pipeline')
+    def test_series_getitem_idx_bool_series_reindex(self):
+        """ Verifies Series.getitem with reindexing by mask indicated by a Boolean Series
+        on Series with various types of indexes """
+
+        def test_impl(A, idx):
+            return A[idx]
+        hpat_func = self.jit(test_impl)
+
+        n, k = 21, 13
+        np.random.seed(0)
+
+        idx_indexes_to_test = {
+            'default': None,
+            'int': np.arange(n),
+            'float': np.arange(n, dtype='float'),
+            'str': gen_strlist(n, 2, 'abcd123 ')
+        }
+
+        idx_data = np.random.choice([True, False], n)
+        for idx_index in idx_indexes_to_test.values():
+            idx = pd.Series(idx_data, idx_index)
+            # create a series with index values in idx_index
+            idx_values = idx_index if idx_index is not None else np.arange(k)
+            series_index = np.random.choice(idx_values, k)
+            S = pd.Series(np.arange(k), index=series_index)
+            with self.subTest(series=S, idx=idx):
+                result = hpat_func(S, idx)
+                result_ref = test_impl(S, idx)
+                pd.testing.assert_series_equal(result, result_ref)
+
+    @skip_sdc_jit('Not implemented in old-pipeline')
+    def test_series_getitem_idx_bool_series_restrictions1(self):
+        """ Verifies negative case of using Series.getitem with Boolean indexer with duplicate index values """
+        def test_impl(A, idx):
+            return A[idx]
+        hpat_func = self.jit(test_impl)
+
+        n = 7
+        np.random.seed(0)
+
+        S = pd.Series(np.arange(n))
+        idx_data = [True, False, False, True, False, False, True]
+        idx = pd.Series(idx_data, index=[0, 1, 2, 3, 4, 5, 0])
+
+        with self.assertRaises(Exception) as context:
+            test_impl(S, idx)
+        pandas_exception = context.exception
+
+        with self.assertRaises(type(pandas_exception)) as context:
+            hpat_func(S, idx)
+        sdc_exception = context.exception
+        self.assertIn(str(sdc_exception), str(pandas_exception))
+
+    @skip_sdc_jit('Not implemented in old-pipeline')
+    def test_series_getitem_idx_bool_series_restrictions2(self):
+        """ Verifies negative case of using Series.getitem with Boolean indexer
+        on a Series with some indices not present in the indexer (reindexing failure) """
+        def test_impl(A, idx):
+            return A[idx]
+        hpat_func = self.jit(test_impl)
+
+        n = 7
+        np.random.seed(0)
+
+        S = pd.Series(np.arange(n), index=[5, 3, 1, 2, 6, 4, 0])
+        idx_data = [True, False, True, True, False]
+        idx = pd.Series(idx_data, index=[4, 3, 2, 1, 0])
+
+        with self.assertRaises(Exception) as context:
+            test_impl(S, idx)
+        pandas_exception = context.exception
+
+        with self.assertRaises(type(pandas_exception)) as context:
+            hpat_func(S, idx)
+        sdc_exception = context.exception
+        self.assertIn(str(sdc_exception), str(pandas_exception))
+
+    @skip_sdc_jit('Not implemented in old-pipeline')
+    def test_series_getitem_idx_bool_series_restrictions3(self):
+        """ Verifies negative case of using Series.getitem with Boolean indexer
+        on a Series with index of different type that in the indexer """
+        def test_impl(A, idx):
+            return A[idx]
+        hpat_func = self.jit(test_impl)
+
+        n = 7
+        np.random.seed(0)
+
+        incompatible_indexes = [
+            np.arange(n),
+            gen_strlist(n, 2, 'abcd123 ')
+        ]
+        for index1, index2 in combinations(incompatible_indexes, 2):
+            S = pd.Series(np.arange(n), index=index1)
+            idx = pd.Series(np.random.choice([True, False], n), index=index2)
+            with self.subTest(series_index=index1, idx_index=index2):
+                with self.assertRaises(TypingError) as raises:
+                    hpat_func(S, idx)
+                msg = 'The index of boolean indexer is not comparable to Series index.'
+                self.assertIn(msg, str(raises.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
New implementation not slower than python on 1 thread, scales on 4 cores, but doesn't scale any further:

  |   |   |   | median | min | max | compile | boxing
-- | -- | -- | -- | -- | -- | -- | -- | --
name | nthreads | type | size |   |   |   |   |  
Series.getitem_idx_bool_array | 1 | Python | 1E+07 | 0.282 | 0.2362 | 0.2978 | NaN | NaN
  |   | SDC | 1E+07 | 0.2732 | 0.2648 | 0.2805 | 0.4704 | 0.0012
  | 4 | SDC | 1E+07 | 0.1273 | 0.1205 | 0.1304 | 0.4575 | 0.0007
  | 8 | SDC | 1E+07 | 0.1396 | 0.1332 | 0.1614 | 0.483 | 0.0012
  | 16 | SDC | 1E+07 | 0.1292 | 0.123 | 0.1514 | 0.4871 | 0.0011
Series.getitem_idx_bool_series | 1 | Python | 1E+07 | 0.306 | 0.2906 | 0.3822 | NaN | NaN
  |   | SDC | 1E+07 | 0.3292 | 0.3225 | 0.3915 | 0.4856 | 0.0013
  | 4 | SDC | 1E+07 | 0.1028 | 0.0966 | 0.1424 | 0.4662 | 0.0008
  | 8 | SDC | 1E+07 | 0.1096 | 0.0993 | 0.1418 | 0.4797 | 0.0014
  | 16 | SDC | 1E+07 | 0.1362 | 0.1185 | 0.1392 | 0.5224 | 0.0021



  |   |   |   | median | min | max | compile | boxing
-- | -- | -- | -- | -- | -- | -- | -- | --
name | nthreads | type | size |   |   |   |   |  
DataFrame.getitem_idx_bool_array | 1 | Python | 1E+07 | 0.8207 | 0.8069 | 0.8369 | NaN | NaN
  |   | SDC | 1E+07 | 0.8649 | 0.8586 | 0.8872 | 0.6992 | 1.2021
  | 4 | SDC | 1E+07 | 0.4043 | 0.3912 | 0.422 | 0.535 | 0.5604
  | 8 | SDC | 1E+07 | 0.3538 | 0.3458 | 0.3788 | 0.7094 | 1.1428
DataFrame.getitem_idx_bool_series | 1 | Python | 1E+07 | 0.8197 | 0.8019 | 0.832 | NaN | NaN
  |   | SDC | 1E+07 | 0.6764 | 0.6649 | 0.6969 | 0.4725 | 1.2326
  | 4 | SDC | 1E+07 | 0.1272 | 0.1256 | 0.1766 | 0.461 | 0.5541
  | 8 | SDC | 1E+07 | 0.3883 | 0.2524 | 0.4399 | 0.5251 | 1.1307