### PR TITLE
Reduce ir for some functions

### DIFF
--- a/sdc/datatypes/hpat_pandas_dataframe_functions.py
+++ b/sdc/datatypes/hpat_pandas_dataframe_functions.py
@@ -1109,8 +1109,8 @@ def sdc_pandas_dataframe_drop_codegen(func_name, func_args, df, drop_cols):
             break
 
     for column_id, column_name in enumerate(saved_df_columns):
-        func_text.append(f'new_col_{column_id}_data_{"df"} = get_dataframe_data({"df"}, '
-                         f'{df_columns_indx[column_name]})')
+        func_text.append(f'new_col_{column_id}_data_{"df"} = {"df"}._data['
+                         f'{df_columns_indx[column_name]}]')
         column_list.append((f'new_col_{column_id}_data_df', column_name))
 
     data = ', '.join(f'"{column_name}": {column}' for column, column_name in column_list)
@@ -1119,7 +1119,7 @@ def sdc_pandas_dataframe_drop_codegen(func_name, func_args, df, drop_cols):
     func_definition.extend([indent + func_line for func_line in func_text])
     func_def = '\n'.join(func_definition)
 
-    global_vars = {'pandas': pandas, 'get_dataframe_data': sdc.hiframes.pd_dataframe_ext.get_dataframe_data}
+    global_vars = {'pandas': pandas}
 
     return func_def, global_vars
 

--- a/sdc/datatypes/hpat_pandas_dataframe_functions.py
+++ b/sdc/datatypes/hpat_pandas_dataframe_functions.py
@@ -1370,8 +1370,7 @@ def df_getitem_slice_idx_main_codelines(self, idx):
     for i, col in enumerate(self.columns):
         res_data = f'res_data_{i}'
         func_lines += [
-            f'  data_{i} = get_dataframe_data(self, {i})',
-            f'  {res_data} = pandas.Series(data_{i}[idx], index=res_index[idx], name="{col}")'
+            f'  {res_data} = pandas.Series((self._data[{i}])[idx], index=res_index[idx], name="{col}")'
         ]
         results.append((col, res_data))
 

--- a/sdc/datatypes/hpat_pandas_dataframe_functions.py
+++ b/sdc/datatypes/hpat_pandas_dataframe_functions.py
@@ -105,7 +105,7 @@ def hpat_pandas_dataframe_index(df):
         empty_df = not df.columns
 
         def hpat_pandas_df_index_none_impl(df):
-            df_len = len(get_dataframe_data(df, 0)) if empty_df == False else 0  # noqa
+            df_len = len(df._data[0]) if empty_df == False else 0  # noqa
 
             return numpy.arange(df_len)
 
@@ -125,10 +125,10 @@ def sdc_pandas_dataframe_values_codegen(df, numba_common_dtype):
 
     Func generated:
     def sdc_pandas_dataframe_values_impl(df):
-        row_len = len(get_dataframe_data(df, 0))
-        df_col_A = get_dataframe_data(df, 0)
-        df_col_B = get_dataframe_data(df, 1)
-        df_col_C = get_dataframe_data(df, 2)
+        row_len = len(df._data[0])
+        df_col_A = df._data[0]
+        df_col_B = df._data[1]
+        df_col_C = df._data[2]
         df_values = numpy.empty(row_len*3, numpy.dtype("float64"))
         for i in range(row_len):
             df_values[i * 3 + 0] = df_col_A[i]
@@ -145,10 +145,10 @@ def sdc_pandas_dataframe_values_codegen(df, numba_common_dtype):
     func_text = []
     column_list = []
     column_len = len(df.columns)
-    func_text.append(f'row_len = len(get_dataframe_data(df, 0))')
+    func_text.append(f'row_len = len(df._data[0])')
 
     for index, column_name in enumerate(df.columns):
-        func_text.append(f'df_col_{index} = get_dataframe_data(df, {index})')
+        func_text.append(f'df_col_{index} = df._data[{index}]')
         column_list.append(f'df_col_{index}')
 
     func_text.append(f'df_values = numpy.empty(row_len*{column_len}, numpy.dtype("{numba_common_dtype}"))')
@@ -160,8 +160,7 @@ def sdc_pandas_dataframe_values_codegen(df, numba_common_dtype):
     func_definition.extend([indent + func_line for func_line in func_text])
     func_def = '\n'.join(func_definition)
 
-    global_vars = {'pandas': pandas, 'numpy': numpy,
-                   'get_dataframe_data': sdc.hiframes.pd_dataframe_ext.get_dataframe_data}
+    global_vars = {'pandas': pandas, 'numpy': numpy}
 
     return func_def, global_vars
 
@@ -250,15 +249,15 @@ def sdc_pandas_dataframe_append_codegen(df, other, _func_name, args):
     other = pd.DataFrame({'A': ['bird', 'fox', 'mouse'], 'C': ['a', np.nan, '']})
     Func generated:
     def sdc_pandas_dataframe_append_impl(df, other, ignore_index=True, verify_integrity=False, sort=None):
-        len_df = len(get_dataframe_data(df, 0))
-        len_other = len(get_dataframe_data(other, 0))
-        new_col_A_data_df = get_dataframe_data(df, 0)
-        new_col_A_data_other = get_dataframe_data(other, 0)
+        len_df = len(df._data[0])
+        len_other = len(other._data[0])
+        new_col_A_data_df = df._data[0]
+        new_col_A_data_other = other._data[0]
         new_col_A = init_series(new_col_A_data_df).append(init_series(new_col_A_data_other))._data
-        new_col_B_data_df = get_dataframe_data(df, 1)
+        new_col_B_data_df = df._data[1]
         new_col_B_data = init_series(new_col_B_data_df)._data
         new_col_B = fill_array(new_col_B_data, len_df+len_other)
-        new_col_C_data_other = get_dataframe_data(other, 1)
+        new_col_C_data_other = other._data[0]
         new_col_C_data = init_series(new_col_C_data_other)._data
         new_col_C = fill_str_array(new_col_C_data, len_df+len_other, push_back=False)
         return pandas.DataFrame({"A": new_col_A, "B": new_col_B, "C": new_col_C)
@@ -288,15 +287,15 @@ def sdc_pandas_dataframe_append_codegen(df, other, _func_name, args):
     func_text = []
     column_list = []
 
-    func_text.append(f'len_df = len(get_dataframe_data(df, 0))')
-    func_text.append(f'len_other = len(get_dataframe_data(other, 0))')
+    func_text.append(f'len_df = len(df._data[0])')
+    func_text.append(f'len_other = len(other._data[0])')
 
     for col_name, col_id in df_columns_indx.items():
-        func_text.append(f'new_col_{col_id}_data_{"df"} = get_dataframe_data({"df"}, {col_id})')
+        func_text.append(f'new_col_{col_id}_data_{"df"} = {"df"}._data[{col_id}]')
         if col_name in other_columns_indx:
             other_col_id = other_columns_indx.get(col_name)
             func_text.append(f'new_col_{col_id}_data_{"other"} = '
-                             f'get_dataframe_data({"other"}, {other_columns_indx.get(col_name)})')
+                             f'{"other"}._data[{other_columns_indx.get(col_name)}]')
             s1 = f'init_series(new_col_{col_id}_data_{"df"})'
             s2 = f'init_series(new_col_{col_id}_data_{"other"})'
             func_text.append(f'new_col_{col_id} = {s1}.append({s2})._data')
@@ -310,7 +309,7 @@ def sdc_pandas_dataframe_append_codegen(df, other, _func_name, args):
 
     for col_name, col_id in other_columns_indx.items():
         if col_name not in df_columns_indx:
-            func_text.append(f'new_col_{col_id}_data_{"other"} = get_dataframe_data({"other"}, {col_id})')
+            func_text.append(f'new_col_{col_id}_data_{"other"} = {"other"}._data[{col_id}]')
             func_text.append(f'new_col_{col_id}_data = init_series(new_col_{col_id}_data_other)._data')
             if col_name in string_type_columns:
                 func_text.append(
@@ -327,7 +326,7 @@ def sdc_pandas_dataframe_append_codegen(df, other, _func_name, args):
     func_definition.extend([indent + func_line for func_line in func_text])
     func_def = '\n'.join(func_definition)
 
-    global_vars = {'pandas': pandas, 'get_dataframe_data': sdc.hiframes.pd_dataframe_ext.get_dataframe_data,
+    global_vars = {'pandas': pandas,
                    'init_series': sdc.hiframes.api.init_series,
                    'fill_array': sdc.datatypes.common_functions.fill_array,
                    'fill_str_array': sdc.datatypes.common_functions.fill_str_array}
@@ -419,9 +418,9 @@ def sdc_pandas_dataframe_append(df, other, ignore_index=True, verify_integrity=F
 # Example func_text for func_name='count' columns=('A', 'B'):
 #
 #         def _df_count_impl(df, axis=0, level=None, numeric_only=False):
-#           series_A = init_series(get_dataframe_data(df, 0))
+#           series_A = init_series(df._data[0])
 #           result_A = series_A.count(level=level)
-#           series_B = init_series(get_dataframe_data(df, 1))
+#           series_B = init_series(df._data[1])
 #           result_B = series_B.count(level=level)
 #           return pandas.Series([result_A, result_B], ['A', 'B'])
 
@@ -432,7 +431,7 @@ def _dataframe_reduce_columns_codegen(func_name, func_params, series_params, col
     func_lines = [f'def _df_{func_name}_impl({joined}):']
     for i, c in enumerate(columns):
         result_c = f'result_{i}'
-        func_lines += [f'  series_{i} = pandas.Series(get_dataframe_data({func_params[0]}, {i}))',
+        func_lines += [f'  series_{i} = pandas.Series({func_params[0]}._data[{i}])',
                        f'  {result_c} = series_{i}.{func_name}({series_params})']
         result_name_list.append(result_c)
     all_results = ', '.join(result_name_list)
@@ -441,8 +440,7 @@ def _dataframe_reduce_columns_codegen(func_name, func_params, series_params, col
     func_lines += [f'  return pandas.Series([{all_results}], [{all_columns}])']
     func_text = '\n'.join(func_lines)
 
-    global_vars = {'pandas': pandas,
-                   'get_dataframe_data': get_dataframe_data}
+    global_vars = {'pandas': pandas}
 
     return func_text, global_vars
 
@@ -473,11 +471,11 @@ def _dataframe_reduce_columns_codegen_head(func_name, func_params, series_params
     Example func_text for func_name='head' columns=('float', 'int', 'string'):
 
         def _df_head_impl(df, n=5):
-            series_float = pandas.Series(get_dataframe_data(df, 0))
+            series_float = pandas.Series(df._data[0])
             result_float = series_float.head(n=n)
-            series_int = pandas.Series(get_dataframe_data(df, 1))
+            series_int = pandas.Series(df._data[1])
             result_int = series_int.head(n=n)
-            series_string = pandas.Series(get_dataframe_data(df, 2))
+            series_string = pandas.Series(df._data[2])
             result_string = series_string.head(n=n)
             return pandas.DataFrame({"float": result_float, "int": result_int, "string": result_string},
                                     index = df._index[:n])
@@ -488,15 +486,14 @@ def _dataframe_reduce_columns_codegen_head(func_name, func_params, series_params
     ind = df_index_codegen_head(df)
     for i, c in enumerate(columns):
         result_c = f'result_{c}'
-        func_lines += [f'  series_{c} = pandas.Series(get_dataframe_data(df, {i}))',
+        func_lines += [f'  series_{c} = pandas.Series(df._data[{i}])',
                        f'  {result_c} = series_{c}.{func_name}({series_params})']
         results.append((columns[i], result_c))
 
     data = ', '.join(f'"{col}": {data}' for col, data in results)
     func_lines += [f'  return pandas.DataFrame({{{data}}}, {ind})']
     func_text = '\n'.join(func_lines)
-    global_vars = {'pandas': pandas,
-                   'get_dataframe_data': get_dataframe_data}
+    global_vars = {'pandas': pandas}
 
     return func_text, global_vars
 
@@ -567,9 +564,9 @@ def _dataframe_codegen_copy(func_params, series_params, df):
     """
     Example func_text for func_name='copy' columns=('A', 'B', 'C'):
         def _df_copy_impl(df, deep=True):
-            series_0 = pandas.Series(get_dataframe_data(df, 0))
+            series_0 = pandas.Series(df._data[0])
             result_0 = series_0.copy(deep=deep)
-            series_1 = pandas.Series(get_dataframe_data(df, 1))
+            series_1 = pandas.Series(df._data[1])
             result_1 = series_1.copy(deep=deep)
             return pandas.DataFrame({"A": result_0, "B": result_1}, index=df._index)
     """
@@ -580,15 +577,14 @@ def _dataframe_codegen_copy(func_params, series_params, df):
     index = df_index_codegen_all(df)
     for i, c in enumerate(df.columns):
         result_c = f"result_{i}"
-        func_lines += [f"  series_{i} = pandas.Series(get_dataframe_data(df, {i}), name='{c}')",
+        func_lines += [f"  series_{i} = pandas.Series(df._data[{i}], name='{c}')",
                        f"  {result_c} = series_{i}.copy({series_params_str})"]
         results.append((c, result_c))
 
     data = ', '.join(f'"{col}": {data}' for col, data in results)
     func_lines += [f"  return pandas.DataFrame({{{data}}}, {index})"]
     func_text = '\n'.join(func_lines)
-    global_vars = {'pandas': pandas,
-                   'get_dataframe_data': get_dataframe_data}
+    global_vars = {'pandas': pandas}
 
     return func_text, global_vars
 
@@ -656,7 +652,7 @@ def _dataframe_apply_columns_codegen(func_name, func_params, series_params, colu
     func_lines = [f'def _df_{func_name}_impl({joined}):']
     for i, c in enumerate(columns):
         result_c = f'result_{i}'
-        func_lines += [f'  series_{i} = pandas.Series(get_dataframe_data({func_params[0]}, {i}))',
+        func_lines += [f'  series_{i} = pandas.Series({func_params[0]}._data[{i}])',
                        f'  {result_c} = series_{i}.{func_name}({series_params})']
         result_name.append((result_c, c))
 
@@ -665,8 +661,7 @@ def _dataframe_apply_columns_codegen(func_name, func_params, series_params, colu
     func_lines += [f'  return pandas.DataFrame({{{data}}})']
     func_text = '\n'.join(func_lines)
 
-    global_vars = {'pandas': pandas,
-                   'get_dataframe_data': get_dataframe_data}
+    global_vars = {'pandas': pandas}
 
     return func_text, global_vars
 
@@ -1089,9 +1084,9 @@ def sdc_pandas_dataframe_drop_codegen(func_name, func_args, df, drop_cols):
      errors="raise"):
         if errors == "raise":
           raise ValueError("The label M is not found in the selected axis")
-        new_col_A_data_df = get_dataframe_data(df, 0)
-        new_col_B_data_df = get_dataframe_data(df, 1)
-        new_col_C_data_df = get_dataframe_data(df, 2)
+        new_col_A_data_df = df._data[0]
+        new_col_B_data_df = df._data[1]
+        new_col_C_data_df = df._data[2]
         return pandas.DataFrame({"A": new_col_A_data_df, "B": new_col_B_data_df, "C": new_col_C_data_df})
 
     """
@@ -1129,11 +1124,11 @@ def _dataframe_codegen_isna(func_name, columns, df):
     Example func_text for func_name='isna' columns=('float', 'int', 'string'):
 
         def _df_isna_impl(df):
-            series_float = pandas.Series(get_dataframe_data(df, 0))
+            series_float = pandas.Series(df._data[0])
             result_float = series_float.isna()
-            series_int = pandas.Series(get_dataframe_data(df, 1))
+            series_int = pandas.Series(df._data[1])
             result_int = series_int.isna()
-            series_string = pandas.Series(get_dataframe_data(df, 2))
+            series_string = pandas.Series(df._data[2])
             result_string = series_string.isna()
             return pandas.DataFrame({"float": result_float, "int": result_int, "string": result_string},
                                     index = df._index)
@@ -1143,15 +1138,14 @@ def _dataframe_codegen_isna(func_name, columns, df):
     index = df_index_codegen_all(df)
     for i, c in enumerate(columns):
         result_c = f'result_{c}'
-        func_lines += [f'  series_{c} = pandas.Series(get_dataframe_data(df, {i}))',
+        func_lines += [f'  series_{c} = pandas.Series(df._data[{i}])',
                        f'  {result_c} = series_{c}.{func_name}()']
         results.append((columns[i], result_c))
 
     data = ', '.join(f'"{col}": {data}' for col, data in results)
     func_lines += [f'  return pandas.DataFrame({{{data}}}, {index})']
     func_text = '\n'.join(func_lines)
-    global_vars = {'pandas': pandas,
-                   'get_dataframe_data': get_dataframe_data}
+    global_vars = {'pandas': pandas}
 
     return func_text, global_vars
 
@@ -1347,7 +1341,7 @@ def sdc_pandas_dataframe_drop(df, labels=None, axis=0, index=None, columns=None,
 def df_length_expr(self):
     """Generate expression to get length of DF"""
     if self.columns:
-        return 'len(get_dataframe_data(self, 0))'
+        return 'len(self._data[0])'
 
     return '0'
 
@@ -1388,7 +1382,7 @@ def df_getitem_tuple_idx_main_codelines(self, literal_idx):
     for col, i in needed_cols.items():
         res_data = f'res_data_{i}'
         func_lines += [
-            f'  data_{i} = get_dataframe_data(self, {i})',
+            f'  data_{i} = self._data [{i}]',
             f'  {res_data} = pandas.Series(data_{i}, index=res_index, name="{col}")'
         ]
         results.append((col, res_data))
@@ -1416,7 +1410,7 @@ def df_getitem_bool_series_idx_main_codelines(self, idx):
         for i, col in enumerate(self.columns):
             res_data = f'res_data_{i}'
             func_lines += [
-                f'  data_{i} = get_dataframe_data(self, {i})',
+                f'  data_{i} = self._data[{i}]',
                 f'  {res_data} = sdc_take(data_{i}, res_index)'
             ]
             results.append((col, res_data))
@@ -1436,7 +1430,7 @@ def df_getitem_bool_series_idx_main_codelines(self, idx):
         for i, col in enumerate(self.columns):
             res_data = f'res_data_{i}'
             func_lines += [
-                f'  data_{i} = get_dataframe_data(self, {i})',
+                f'  data_{i} = self._data[{i}]',
                 f'  {res_data} = sdc_take(data_{i}, selected_pos)'
             ]
             results.append((col, res_data))
@@ -1460,7 +1454,7 @@ def df_getitem_bool_array_idx_main_codelines(self, idx):
     for i, col in enumerate(self.columns):
         res_data = f'res_data_{i}'
         func_lines += [
-            f'  data_{i} = get_dataframe_data(self, {i})',
+            f'  data_{i} = self._data[{i}]',
             f'  {res_data} = sdc_take(data_{i}, taken_pos)'
         ]
         results.append((col, res_data))
@@ -1483,9 +1477,9 @@ def df_getitem_slice_idx_codegen(self, idx):
     Example of generated implementation with provided index:
         def _df_getitem_slice_idx_impl(self, idx)
           res_index = self._index
-          data_0 = get_dataframe_data(self, 0)
+          data_0 = self._data[0]
           res_data_0 = pandas.Series(data_0[idx], index=res_index[idx], name="A")
-          data_1 = get_dataframe_data(self, 1)
+          data_1 = self._data [1]
           res_data_1 = pandas.Series(data_1[idx], index=res_index, name="B")
           return pandas.DataFrame({"A": res_data_0, "B": res_data_1}, index=res_index[idx])
     """
@@ -1496,8 +1490,7 @@ def df_getitem_slice_idx_codegen(self, idx):
         # raise KeyError if input DF is empty
         func_lines += df_getitem_key_error_codelines()
     func_text = '\n'.join(func_lines)
-    global_vars = {'pandas': pandas, 'numpy': numpy,
-                   'get_dataframe_data': get_dataframe_data}
+    global_vars = {'pandas': pandas, 'numpy': numpy}
 
     return func_text, global_vars
 
@@ -1507,9 +1500,9 @@ def df_getitem_tuple_idx_codegen(self, idx):
     Example of generated implementation with provided index:
         def _df_getitem_tuple_idx_impl(self, idx)
           res_index = self._index
-          data_1 = get_dataframe_data(self, 1)
+          data_1 = self._data[1]
           res_data_1 = pandas.Series(data_1, index=res_index, name="B")
-          data_2 = get_dataframe_data(self, 2)
+          data_2 = self._data[2]
           res_data_2 = pandas.Series(data_2, index=res_index, name="C")
           return pandas.DataFrame({"B": res_data_1, "C": res_data_2}, index=res_index)
     """
@@ -1524,8 +1517,7 @@ def df_getitem_tuple_idx_codegen(self, idx):
         func_lines += df_getitem_key_error_codelines()
 
     func_text = '\n'.join(func_lines)
-    global_vars = {'pandas': pandas, 'numpy': numpy,
-                   'get_dataframe_data': get_dataframe_data}
+    global_vars = {'pandas': pandas, 'numpy': numpy}
 
     return func_text, global_vars
 
@@ -1534,7 +1526,7 @@ def df_getitem_bool_series_idx_codegen(self, idx):
     """
     Example of generated implementation with provided index:
         def _df_getitem_bool_series_idx_impl(self, idx):
-          length = len(get_dataframe_data(self, 0))
+          length = len(self._data[0])
           if length > len(idx):
             msg = "Unalignable boolean Series provided as indexer " + \
                   "(index of the boolean Series and of the indexed object do not match)."
@@ -1542,9 +1534,9 @@ def df_getitem_bool_series_idx_codegen(self, idx):
           # do not trim idx._data to length as getitem_by_mask handles such case
           res_index = getitem_by_mask(self.index, idx._data)
           # df index is default, same as positions so it can be used in take
-          data_0 = get_dataframe_data(self, 0)
+          data_0 = self._data[0]
           res_data_0 = sdc_take(data_0, res_index)
-          data_1 = get_dataframe_data(self, 1)
+          data_1 = self._data[1]
           res_data_1 = sdc_take(data_1, res_index)
           return pandas.DataFrame({"A": res_data_0, "B": res_data_1}, index=res_index)
     """
@@ -1552,7 +1544,6 @@ def df_getitem_bool_series_idx_codegen(self, idx):
     func_lines += df_getitem_bool_series_idx_main_codelines(self, idx)
     func_text = '\n'.join(func_lines)
     global_vars = {'pandas': pandas, 'numpy': numpy,
-                   'get_dataframe_data': get_dataframe_data,
                    'getitem_by_mask': getitem_by_mask,
                    'sdc_take': _sdc_take,
                    'sdc_reindex_series': sdc_reindex_series,
@@ -1565,14 +1556,14 @@ def df_getitem_bool_array_idx_codegen(self, idx):
     """
     Example of generated implementation with provided index:
         def _df_getitem_bool_array_idx_impl(self, idx):
-          length = len(get_dataframe_data(self, 0))
+          length = len(self._data[0])
           if length != len(idx):
             raise ValueError("Item wrong length.")
           taken_pos = getitem_by_mask(numpy.arange(length), idx)
           res_index = sdc_take(self.index, taken_pos)
-          data_0 = get_dataframe_data(self, 0)
+          data_0 = self._data[0]
           res_data_0 = sdc_take(data_0, taken_pos)
-          data_1 = get_dataframe_data(self, 1)
+          data_1 = self._data[1]
           res_data_1 = sdc_take(data_1, taken_pos)
           return pandas.DataFrame({"A": res_data_0, "B": res_data_1}, index=res_index)
     """
@@ -1580,7 +1571,6 @@ def df_getitem_bool_array_idx_codegen(self, idx):
     func_lines += df_getitem_bool_array_idx_main_codelines(self, idx)
     func_text = '\n'.join(func_lines)
     global_vars = {'pandas': pandas, 'numpy': numpy,
-                   'get_dataframe_data': get_dataframe_data,
                    'getitem_by_mask': getitem_by_mask,
                    'sdc_take': _sdc_take}
 
@@ -1613,7 +1603,7 @@ def sdc_pandas_dataframe_getitem(self, idx):
 
         def _df_getitem_str_literal_idx_impl(self, idx):
             if key_error == False:  # noqa
-                data = get_dataframe_data(self, col_idx)
+                data = self._data[col_idx]
                 return pandas.Series(data, index=self._index, name=idx)
             else:
                 raise KeyError('Column is not in the DataFrame')
@@ -1675,7 +1665,7 @@ def sdc_pandas_dataframe_accessor_getitem(self, idx):
                 def df_getitem_iat_tuple_impl(self, idx):
                     row, _ = idx
                     if -1 < row < len(self._dataframe.index):
-                        data = get_dataframe_data(self._dataframe, col)
+                        data = self._dataframe._data[col]
                         res_data = pandas.Series(data)
                         return res_data.iat[row]
 
@@ -1822,7 +1812,7 @@ def sdc_pandas_dataframe_groupby(self, by=None, axis=0, level=None, as_index=Tru
                                           group_keys=True, squeeze=False, observed=False):
 
         grouped = Dict.empty(by_type, list_type)
-        by_column_data = get_dataframe_data(self, column_id)
+        by_column_data = self._data[column_id]
         for i in numpy.arange(len(by_column_data)):
             if isna(by_column_data, i):
                 continue
@@ -1862,7 +1852,7 @@ def df_add_column_codelines(self, key):
     for i, col in enumerate(self.columns):
         res_data = f'res_data_{i}'
         func_lines += [
-            f'  data_{i} = get_dataframe_data(self, {i})',
+            f'  data_{i} = self._data[{i}]',
             f'  {res_data} = pandas.Series(data_{i}, index=res_index, name="{col}")',
         ]
         results.append((col, res_data))
@@ -1888,7 +1878,7 @@ def df_replace_column_codelines(self, key):
         if literal_key == col:
             func_lines += [f'  data_{i} = value']
         else:
-            func_lines += [f'  data_{i} = get_dataframe_data(self, {i})']
+            func_lines += [f'  data_{i} = self._data[{i}]']
 
         res_data = f'res_data_{i}'
         func_lines += [
@@ -1906,15 +1896,15 @@ def df_add_column_codegen(self, key):
     """
     Example of generated implementation:
     def _df_add_column_impl(self, key, value):
-      length = len(get_dataframe_data(self, 0))
+      length = len(self._data[0])
       if length == 0:
         raise SDCLimitation("Could not set item for empty DataFrame")
       elif length != len(value):
         raise ValueError("Length of values does not match length of index")
       res_index = numpy.arange(length)
-      data_0 = get_dataframe_data(self, 0)
+      data_0 = self._data[0]
       res_data_0 = pandas.Series(data_0, index=res_index, name="A")
-      data_1 = get_dataframe_data(self, 1)
+      data_1 = self._data[1]
       res_data_1 = pandas.Series(data_1, index=res_index, name="C")
       new_res_data = pandas.Series(value, index=res_index, name="B")
       return pandas.DataFrame({"A": res_data_0, "C": res_data_1, "B": new_res_data}, index=res_index)
@@ -1924,7 +1914,6 @@ def df_add_column_codegen(self, key):
 
     func_text = '\n'.join(func_lines)
     global_vars = {'pandas': pandas, 'numpy': numpy,
-                   'get_dataframe_data': get_dataframe_data,
                    'SDCLimitation': SDCLimitation}
 
     return func_text, global_vars
@@ -1934,7 +1923,7 @@ def df_replace_column_codegen(self, key):
     """
     Example of generated implementation:
     def _df_replace_column_impl(self, key, value):
-      length = len(get_dataframe_data(self, 0))
+      length = len(self._data[0])
       if length == 0:
         raise SDCLimitation("Could not set item for DataFrame with empty columns")
       elif length != len(value):
@@ -1942,7 +1931,7 @@ def df_replace_column_codegen(self, key):
       res_index = numpy.arange(length)
       data_0 = value
       res_data_0 = pandas.Series(data_0, index=res_index, name="A")
-      data_1 = get_dataframe_data(self, 1)
+      data_1 = self._data[1]
       res_data_1 = pandas.Series(data_1, index=res_index, name="C")
       return pandas.DataFrame({"A": res_data_0, "C": res_data_1}, index=res_index)
     """
@@ -1951,7 +1940,6 @@ def df_replace_column_codegen(self, key):
 
     func_text = '\n'.join(func_lines)
     global_vars = {'pandas': pandas, 'numpy': numpy,
-                   'get_dataframe_data': get_dataframe_data,
                    'SDCLimitation': SDCLimitation}
 
     return func_text, global_vars

--- a/sdc/datatypes/hpat_pandas_dataframe_rolling_functions.py
+++ b/sdc/datatypes/hpat_pandas_dataframe_rolling_functions.py
@@ -123,8 +123,8 @@ def df_rolling_method_other_df_codegen(method_name, self, other, args=None, kws=
             f'    raise ValueError("Method rolling.{method_name}(). The object pairwise\\n expected: False, None")'
         ]
 
-    data_length = 'len(get_dataframe_data(self._data, 0))' if data_columns else '0'
-    other_length = 'len(get_dataframe_data(other, 0))' if other_columns else '0'
+    data_length = 'len(self._data._data[0])' if data_columns else '0'
+    other_length = 'len(other._data[0])' if other_columns else '0'
     func_lines += [f'  length = max([{data_length}, {other_length}])']
 
     for col in all_columns:
@@ -134,8 +134,8 @@ def df_rolling_method_other_df_codegen(method_name, self, other, args=None, kws=
             method_kws['other'] = other_series
             method_params = ', '.join(args + kwsparams2list(method_kws))
             func_lines += [
-                f'  data_{col} = get_dataframe_data(self._data, {data_columns[col]})',
-                f'  other_data_{col} = get_dataframe_data(other, {other_columns[col]})',
+                f'  data_{col} = self._data._data[{data_columns[col]}]',
+                f'  other_data_{col} = other._data[{other_columns[col]}]',
                 f'  series_{col} = pandas.Series(data_{col})',
                 f'  {other_series} = pandas.Series(other_data_{col})',
                 f'  rolling_{col} = series_{col}.rolling({rolling_params})',
@@ -153,8 +153,7 @@ def df_rolling_method_other_df_codegen(method_name, self, other, args=None, kws=
     func_lines += [f'  return pandas.DataFrame({{{data}}})']
     func_text = '\n'.join(func_lines)
 
-    global_vars = {'numpy': numpy, 'pandas': pandas, 'float64': float64,
-                   'get_dataframe_data': get_dataframe_data}
+    global_vars = {'numpy': numpy, 'pandas': pandas, 'float64': float64}
 
     return func_text, global_vars
 
@@ -168,7 +167,7 @@ def df_rolling_method_main_codegen(method_params, df_columns, method_name):
     for idx, col in enumerate(df_columns):
         res_data = f'result_data_{col}'
         func_lines += [
-            f'  data_{col} = get_dataframe_data(self._data, {idx})',
+            f'  data_{col} = self._data._data[{idx}]',
             f'  series_{col} = pandas.Series(data_{col})',
             f'  rolling_{col} = series_{col}.rolling({rolling_params})',
             f'  result_{col} = rolling_{col}.{method_name}({method_params_as_str})',
@@ -208,7 +207,7 @@ def gen_df_rolling_method_other_none_codegen(rewrite_name=None):
         func_lines += df_rolling_method_main_codegen(method_params, self.data.columns, method_name)
         func_text = '\n'.join(func_lines)
 
-        global_vars = {'pandas': pandas, 'get_dataframe_data': get_dataframe_data}
+        global_vars = {'pandas': pandas}
 
         return func_text, global_vars
 
@@ -233,7 +232,7 @@ def df_rolling_method_codegen(method_name, self, args=None, kws=None):
     func_lines += df_rolling_method_main_codegen(method_params, self.data.columns, method_name)
     func_text = '\n'.join(func_lines)
 
-    global_vars = {'pandas': pandas, 'get_dataframe_data': get_dataframe_data}
+    global_vars = {'pandas': pandas}
 
     return func_text, global_vars
 

--- a/sdc/datatypes/hpat_pandas_groupby_functions.py
+++ b/sdc/datatypes/hpat_pandas_groupby_functions.py
@@ -141,10 +141,10 @@ def sdc_pandas_dataframe_getitem(self, idx):
             if idx_is_literal_str == True:  # noqa
                 # no need to pass index into this series, as we group by array
                 target_series = pandas.Series(
-                    data=get_dataframe_data(self._parent, target_col_id_literal),
+                    data=self._parent._data[target_col_id_literal],
                     name=self._parent._columns[target_col_id_literal]
                 )
-                by_arr_data = get_dataframe_data(self._parent, by_col_id_literal)
+                by_arr_data = self._parent._data[by_col_id_literal]
                 return init_series_groupby(target_series, by_arr_data, self._data, self._sort)
             else:
                 return init_dataframe_groupby(self._parent, by_col_id_literal, self._data, self._sort, idx)
@@ -182,7 +182,7 @@ def _sdc_pandas_groupby_generic_func_codegen(func_name, columns, func_params, de
     # TODO: remove conversion from Numba typed.List to reflected one while creating group_arr_{i}
     func_lines.extend(['\n'.join([
         f'  result_data_{i} = numpy.empty(res_index_len, dtype=res_arrays_dtypes[{i}])',
-        f'  column_data_{i} = get_dataframe_data({df}, {column_ids[i]})',
+        f'  column_data_{i} = {df}._data[{column_ids[i]}]',
         f'  for j in numpy.arange(res_index_len):',
         f'    group_arr_{i} = _sdc_take(column_data_{i}, list({groupby_dict}[group_keys[j]]))',
         f'    group_series_{i} = pandas.Series(group_arr_{i})',
@@ -204,8 +204,7 @@ def _sdc_pandas_groupby_generic_func_codegen(func_name, columns, func_params, de
                    'numpy': numpy,
                    '_sdc_asarray': _sdc_asarray,
                    '_sdc_take': _sdc_take,
-                   'sdc_arrays_argsort': sdc_arrays_argsort,
-                   'get_dataframe_data': get_dataframe_data}
+                   'sdc_arrays_argsort': sdc_arrays_argsort}
 
     return func_text, global_vars
 

--- a/sdc/hiframes/pd_dataframe_ext.py
+++ b/sdc/hiframes/pd_dataframe_ext.py
@@ -321,7 +321,7 @@ def df_len_overload(df):
 
     if len(df.columns) == 0:  # empty df
         return lambda df: 0
-    return lambda df: len(get_dataframe_data(df, 0))
+    return lambda df: len(df._data[0])
 
 if sdc.config.config_pipeline_hpat_default:
     @overload(operator.getitem)  # TODO: avoid lowering?


### PR DESCRIPTION
* Manually inline `get_dataframe_data` function calls to reduce excessive increfs/decrefs for large dataframes

`get_dataframe_data`  function itself is still here to avoid breaking any ongoing PR