### PR TITLE
Docs for pandas.Series()

### DIFF
--- a/docs/source/buildscripts/sdc_object_utils.py
+++ b/docs/source/buildscripts/sdc_object_utils.py
@@ -69,7 +69,6 @@ exclude_sdc_submodules = [
     'sdc.hdist',
     'sdc.distributed_analysis',
     'sdc.hdatetime_ext',
-    'sdc.hiframes',
     'sdc.io.csv_ext',
     'sdc.hio',
     'sdc.hiframes.join',

--- a/sdc/hiframes/pd_series_ext.py
+++ b/sdc/hiframes/pd_series_ext.py
@@ -1046,6 +1046,15 @@ type_callable(operator.sub)(type_sub)
 
 @overload(pd.Series)
 def pd_series_overload(data=None, index=None, dtype=None, name=None, copy=False, fastpath=False):
+    """
+    Intel Scalable Dataframe Compiler User Guide
+    ********************************************
+    Pandas API: pandas.Series
+
+    Limitations
+    -----------
+    - Parameters `dtype` and `copy` are currently unsupported by Intel Scalable Dataframe Compiler.
+    """
 
     is_index_none = isinstance(index, types.NoneType) or index is None
 

--- a/sdc/hiframes/pd_series_ext.py
+++ b/sdc/hiframes/pd_series_ext.py
@@ -1053,7 +1053,17 @@ def pd_series_overload(data=None, index=None, dtype=None, name=None, copy=False,
 
     Limitations
     -----------
-    - Parameters `dtype` and `copy` are currently unsupported by Intel Scalable Dataframe Compiler.
+    - Parameters ``dtype`` and ``copy`` are currently unsupported by Intel Scalable Dataframe Compiler.
+
+    Examples
+    --------
+    Create Series with data [1, 2, 3] and index ['A', 'B', 'C'].
+    >>> pd.Series([1, 2, 3], ['A', 'B', 'C'])
+
+    .. seealso::
+
+        :ref:`DataFrame <pandas.DataFrame>`
+            DataFrame constructor.
     """
 
     is_index_none = isinstance(index, types.NoneType) or index is None

--- a/sdc/hiframes/pd_series_ext.py
+++ b/sdc/hiframes/pd_series_ext.py
@@ -1058,6 +1058,7 @@ def pd_series_overload(data=None, index=None, dtype=None, name=None, copy=False,
     Examples
     --------
     Create Series with data [1, 2, 3] and index ['A', 'B', 'C'].
+
     >>> pd.Series([1, 2, 3], ['A', 'B', 'C'])
 
     .. seealso::

--- a/sdc/hiframes/pd_series_ext.py
+++ b/sdc/hiframes/pd_series_ext.py
@@ -1054,6 +1054,7 @@ def pd_series_overload(data=None, index=None, dtype=None, name=None, copy=False,
     Limitations
     -----------
     - Parameters ``dtype`` and ``copy`` are currently unsupported by Intel Scalable Dataframe Compiler.
+    - Parameter ``dtype`` types iterable and dict are currently unsupported by Intel Scalable Dataframe Compiler.
 
     Examples
     --------

--- a/sdc/rewrites/dataframe_constructor.py
+++ b/sdc/rewrites/dataframe_constructor.py
@@ -160,32 +160,13 @@ if not config_pipeline_hpat_default:
     @overload(DataFrame)
     def pd_dataframe_overload(data, index=None, columns=None, dtype=None, copy=False):
         """
-        Two-dimensional size-mutable, potentially heterogeneous tabular data
-        structure with labeled axes (rows and columns). Arithmetic operations
-        align on both row and column labels. Can be thought of as a dict-like
-        container for Series objects. The primary pandas data structure.
+        Intel Scalable Dataframe Compiler User Guide
+        ********************************************
+        Pandas API: pandas.DataFrame
 
-        Parameters
-        ----------
-        data : dict
-            Dict can contain Series, arrays, constants, or list-like objects
-
-        index : array-like
-            Index to use for resulting frame. Will default to RangeIndex if
-            no indexing information part of input data and no index provided
-
-        columns : Index or array-like
-            Column labels to use for resulting frame. Will default to
-            RangeIndex (0, 1, 2, ..., n) if no column labels are provided
-            *unsupported*
-
-        dtype : dtype, default None
-            Data type to force. Only a single dtype is allowed. If None, infer
-            *unsupported*
-
-        copy : boolean, default False
-            Copy data from inputs. Only affects DataFrame / 2d ndarray input
-            *unsupported*
+        Limitations
+        -----------
+        - Parameters `dtype` and `copy` are currently unsupported by Intel Scalable Dataframe Compiler.
         """
 
         ty_checker = TypeChecker('Method DataFrame')


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1541421/77000445-798d3000-6969-11ea-9375-16822537f91e.png)

Note:
1. Removed filter for sdc.hiframes because overload(pd.Series) in it
2. I know only unsupported parameters as limitations.
3. Examples for series are in other functions.
4. See also - no in Pandas docs, so no in SDC docs.