### PR TITLE
Fix Pandas->SDC docs formatting.

### DIFF
--- a/docs/source/buildscripts/apiref_generator.py
+++ b/docs/source/buildscripts/apiref_generator.py
@@ -303,7 +303,7 @@ def reformat_pandas_params(title, text):
             line = lines[0]
             line = line.strip()
             idx = line.find(' : ')
-            if idx >= 0 & line[0:idx].isalnum():
+            if idx >= 0 & line[0:idx].isalnum() and line[0:idx].isidentifier():
                 # Check if previous parameter existed. If so, need to add it to reformatted text
                 if param != '':
                     new_text += _get_param_text(title, param) + '\n' + reindent(description, indent+4) + '\n'


### PR DESCRIPTION
Chack that text before " : " is correct Python variable name.
Eliminated text like "* dict, e.g. {{'foo' : ".

Before:
![image](https://user-images.githubusercontent.com/1541421/77160503-7c4a6b00-6ab8-11ea-8965-2db0594b683d.png)

After:
![image](https://user-images.githubusercontent.com/1541421/77160443-6046c980-6ab8-11ea-8000-2e07eff4be2f.png)
