### PR TITLE
Add scipy to doc build env to avoid examples failure

### DIFF
--- a/buildscripts/build_doc.py
+++ b/buildscripts/build_doc.py
@@ -96,7 +96,7 @@ if __name__ == '__main__':
     sdc_utils = SDC_Build_Utilities(args.python, args.sdc_channel)
     sdc_utils.log_info('Build Intel(R) SDC documentation', separate=True)
     sdc_utils.log_info(sdc_utils.line_double)
-    sdc_utils.create_environment(['sphinx', 'sphinxcontrib-programoutput'])
+    sdc_utils.create_environment(['sphinx', 'sphinxcontrib-programoutput', 'scipy'])
     sdc_utils.install_conda_package(['sdc'])
 
     build_doc(sdc_utils)


### PR DESCRIPTION
Examples in documentation build fails due to lack of scipy package in build environment.
That is why error output is present in current documentation:
pkg_resources.DistributionNotFound: The 'scipy' distribution was not found and is required by the application