### PR TITLE
add docstring for DF.getitem

### DIFF
--- a/sdc/datatypes/hpat_pandas_dataframe_functions.py
+++ b/sdc/datatypes/hpat_pandas_dataframe_functions.py
@@ -1700,6 +1700,114 @@ gen_df_getitem_bool_array_idx_impl = gen_impl_generator(
 
 @sdc_overload(operator.getitem)
 def sdc_pandas_dataframe_getitem(self, idx):
+    """
+    Intel Scalable Dataframe Compiler User Guide
+    ********************************************
+    Pandas API: pandas.DataFrame.getitem
+
+    Get data from a DataFrame by indexer.
+
+    Limitations
+    -----------
+    Supported ``key`` can be one of the following:
+
+    * String literal, e.g. :obj:`df['A']`
+    * A slice, e.g. :obj:`df[2:5]`
+    * A tuple of string, e.g. :obj:`df[('A', 'B')]`
+    * An array of booleans, e.g. :obj:`df[True,False]`
+    * A series of booleans, e.g. :obj:`df(series([True,False]))`
+
+    Supported getting a column through getting attribute.
+
+    Examples
+    --------
+    .. literalinclude:: ../../../examples/dataframe/getitem/df_getitem_attr.py
+       :language: python
+       :lines: 37-
+       :caption: Getting Pandas DataFrame column through getting attribute.
+       :name: ex_dataframe_getitem
+
+    .. command-output:: python ./dataframe/getitem/df_getitem_attr.py
+       :cwd: ../../../examples
+
+    .. literalinclude:: ../../../examples/dataframe/getitem/df_getitem.py
+       :language: python
+       :lines: 37-
+       :caption: Getting Pandas DataFrame column where key is a string.
+       :name: ex_dataframe_getitem
+
+    .. command-output:: python ./dataframe/getitem/df_getitem.py
+       :cwd: ../../../examples
+
+    .. literalinclude:: ../../../examples/dataframe/getitem/df_getitem_slice.py
+       :language: python
+       :lines: 34-
+       :caption: Getting slice of Pandas DataFrame.
+       :name: ex_dataframe_getitem
+
+    .. command-output:: python ./dataframe/getitem/df_getitem_slice.py
+       :cwd: ../../../examples
+
+    .. literalinclude:: ../../../examples/dataframe/getitem/df_getitem_tuple.py
+       :language: python
+       :lines: 37-
+       :caption: Getting Pandas DataFrame elements where key is a tuple of strings.
+       :name: ex_dataframe_getitem
+
+    .. command-output:: python ./dataframe/getitem/df_getitem_tuple.py
+       :cwd: ../../../examples
+
+    .. literalinclude:: ../../../examples/dataframe/getitem/df_getitem_array.py
+       :language: python
+       :lines: 34-
+       :caption: Getting Pandas DataFrame elements where key is an array of booleans.
+       :name: ex_dataframe_getitem
+
+    .. command-output:: python ./dataframe/getitem/df_getitem_array.py
+       :cwd: ../../../examples
+
+    .. literalinclude:: ../../../examples/dataframe/getitem/df_getitem_series.py
+       :language: python
+       :lines: 34-
+       :caption: Getting Pandas DataFrame elements where key is series of booleans.
+       :name: ex_dataframe_getitem
+
+    .. command-output:: python ./dataframe/getitem/df_getitem_series.py
+       :cwd: ../../../examples
+
+    .. seealso::
+        :ref:`Series.getitem <pandas.Series.getitem>`
+            Get value(s) of Series by key.
+        :ref:`Series.setitem <pandas.Series.setitem>`
+            Set value to Series by index
+        :ref:`Series.loc <pandas.Series.loc>`
+            Access a group of rows and columns by label(s) or a boolean array.
+        :ref:`Series.iloc <pandas.Series.iloc>`
+            Purely integer-location based indexing for selection by position.
+        :ref:`Series.at <pandas.Series.at>`
+            Access a single value for a row/column label pair.
+        :ref:`Series.iat <pandas.Series.iat>`
+            Access a single value for a row/column pair by integer position.
+        :ref:`DataFrame.setitem <pandas.DataFrame.setitem>`
+            Set value to DataFrame by index
+        :ref:`DataFrame.loc <pandas.DataFrame.loc>`
+            Access a group of rows and columns by label(s) or a boolean array.
+        :ref:`DataFrame.iloc <pandas.DataFrame.iloc>`
+            Purely integer-location based indexing for selection by position.
+        :ref:`DataFrame.at <pandas.DataFrame.at>`
+            Access a single value for a row/column label pair.
+        :ref:`DataFrame.iat <pandas.DataFrame.iat>`
+            Access a single value for a row/column pair by integer position.
+
+    Intel Scalable Dataframe Compiler Developer Guide
+    *************************************************
+
+    Pandas DataFrame method :meth:`pandas.DataFrame.getitem` implementation.
+
+    .. only:: developer
+
+    Test: python -m sdc.runtests -k sdc.tests.test_dataframe.TestDataFrame.test_df_getitem*
+    """
     ty_checker = TypeChecker('Operator getitem().')
 
     if not isinstance(self, DataFrameType):


### PR DESCRIPTION
docstring for `df.getitem` was accidentally dropped. So the docstring was restored.