### PR TITLE
Docs fix for external links 

### DIFF
--- a/docs/source/ext_links.txt
+++ b/docs/source/ext_links.txt
@@ -2,6 +2,7 @@
     **********************************************************
     THESE ARE EXTERNAL PROJECT LINKS USED IN THE DOCUMENTATION
     **********************************************************
+.. _Python*: https://www.python.org/
 .. _NumPy*: https://numpy.org/
 .. _Numba*: https://numba.pydata.org/
 .. _Pandas*: https://pandas.pydata.org/

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -4,7 +4,7 @@
 Getting Started
 ===============
 
-Intel® Scalable Dataframe Compiler (Intel® SDC) extends capabilities of Numba* to compile a subset
+Intel® Scalable Dataframe Compiler (Intel® SDC) extends capabilities of `Numba*`_ to compile a subset
 of `Pandas*`_ into native code. Being integral part of `Numba*`_ it allows to combine regular `NumPy*`_ codes
 with `Pandas*`_ operations.
 
@@ -30,10 +30,10 @@ binning, and finally by feeding the cleaned data into machine learning algorithm
 
 We also recommend to read `A ~5 minute guide to Numba <https://numba.pydata.org/numba-doc/dev/user/5minguide.html>`_
 for getting started with `Numba*`_.
- 
+
 Installation
 #############
-You can use conda and pip package managers to install Intel® SDC into your Python* environment.
+You can use conda and pip package managers to install Intel® SDC into your `Python*`_ environment.
 
 Intel SDC is available on the Anaconda Cloud intel/label/beta channel.
 Distribution includes Intel SDC for Python 3.6 and 3.7 for Windows and Linux platforms.

--- a/docs/source/performance.rst
+++ b/docs/source/performance.rst
@@ -76,5 +76,5 @@ parallelism available in a JIT-region. To do that you need to add ``parallel=Tru
 
 Other Performance Tips
 ----------------------
-Please refer to `Numba Performance Tips<https://numba.pydata.org/numba-doc/dev/user/performance-tips.html>`_
+Please refer to `Numba Performance Tips <https://numba.pydata.org/numba-doc/dev/user/performance-tips.html>`_
 for additional hints on obtaining good performance with Intel SDC.


### PR DESCRIPTION
I have found that there are several links to Python but they are not resolved until `ext_links.txt` contains link to it.
Also there are `Python*` and `Numba*` mentions without links.
Also I have found that link is not created if there is no space between `Numba Performance Tips` and `<`.