### PR TITLE
Fix limitations in Series constructor

### DIFF
--- a/sdc/hiframes/pd_series_ext.py
+++ b/sdc/hiframes/pd_series_ext.py
@@ -1053,8 +1053,8 @@ def pd_series_overload(data=None, index=None, dtype=None, name=None, copy=False,
 
     Limitations
     -----------
-    - Parameters ``dtype`` and ``copy`` are currently unsupported by Intel Scalable Dataframe Compiler.
-    - Parameter ``dtype`` types iterable and dict are currently unsupported by Intel Scalable Dataframe Compiler.
+    - Parameters ``dtype`` and ``copy`` are currently unsupported.
+    - Types iterable and dict as ``data`` parameter are currently unsupported.
 
     Examples
     --------


### PR DESCRIPTION
I think "by Intel Scalable DataFrame Compiler" is redundant in doc strings