### PR TITLE
Fix warning about using nopython=True with ngit

### DIFF
--- a/sdc/hiframes/pd_dataframe_ext.py
+++ b/sdc/hiframes/pd_dataframe_ext.py
@@ -160,7 +160,7 @@ def has_parent(typingctx, df=None):
 # TODO: alias analysis
 # this function should be used for getting df._data for alias analysis to work
 # no_cpython_wrapper since Array(DatetimeDate) cannot be boxed
-@numba.njit(nopython=True, no_cpython_wrapper=True, inline='always')
+@numba.njit(no_cpython_wrapper=True, inline='always')
 def get_dataframe_data(df, i):
     return df._data[i]
 


### PR DESCRIPTION
Due to this warning we have this in docs:
![image](https://user-images.githubusercontent.com/1541421/77536190-04f84b00-6ead-11ea-8aac-2f60a078ef9c.png)
