### PR TITLE
Add minimal fixes for using Numba 0.49.0rc1

### DIFF
--- a/sdc/datatypes/common_functions.py
+++ b/sdc/datatypes/common_functions.py
@@ -35,7 +35,7 @@ import pandas
 from pandas.core.indexing import IndexingError
 
 import numba
-from numba.targets import quicksort
+from numba.misc import quicksort
 from numba import types
 from numba.errors import TypingError
 from numba.extending import register_jitable

--- a/sdc/datatypes/hpat_pandas_dataframe_functions.py
+++ b/sdc/datatypes/hpat_pandas_dataframe_functions.py
@@ -38,7 +38,7 @@ import sdc
 from pandas.core.indexing import IndexingError
 
 from numba import types
-from numba.special import literally
+from numba.misc.special import literally
 from numba.typed import List, Dict
 from numba.errors import TypingError
 from pandas.core.indexing import IndexingError

--- a/sdc/datatypes/hpat_pandas_groupby_functions.py
+++ b/sdc/datatypes/hpat_pandas_groupby_functions.py
@@ -40,7 +40,7 @@ from numba.extending import intrinsic
 from numba.targets.registry import cpu_target
 from numba.typed import List, Dict
 from numba.typing import signature
-from numba.special import literally
+from numba.misc.special import literally
 
 from sdc.datatypes.common_functions import sdc_arrays_argsort, _sdc_asarray, _sdc_take
 from sdc.datatypes.hpat_pandas_groupby_types import DataFrameGroupByType, SeriesGroupByType

--- a/sdc/distributed.py
+++ b/sdc/distributed.py
@@ -40,7 +40,8 @@ from collections import defaultdict
 import numpy as np
 
 import numba
-from numba import ir, ir_utils, postproc, types
+from numba import ir, ir_utils, types
+from numba.core import postproc
 from numba.ir_utils import (
     mk_unique_var,
     replace_vars_inner,

--- a/sdc/hiframes/join.py
+++ b/sdc/hiframes/join.py
@@ -34,6 +34,7 @@ from collections import defaultdict
 import numpy as np
 
 import numba
+import numba.analysis
 from numba import generated_jit, ir, ir_utils, typeinfer, types
 from numba.extending import overload
 from numba.ir_utils import (visit_vars_inner, replace_vars_inner,

--- a/sdc/hiframes/pd_series_type.py
+++ b/sdc/hiframes/pd_series_type.py
@@ -32,7 +32,7 @@ from numba import types, cgutils
 from numba.numpy_support import from_dtype
 from numba.extending import (models, register_model, make_attribute_wrapper, lower_builtin)
 from numba.targets.imputils import (impl_ret_new_ref, iternext_impl, RefType)
-from numba.targets.arrayobj import (make_array, _getitem_array1d)
+from numba.targets.arrayobj import make_array
 
 from sdc.str_arr_ext import string_array_type
 from sdc.str_ext import string_type, list_string_array_type

--- a/sdc/rewrites/read_csv_consts.py
+++ b/sdc/rewrites/read_csv_consts.py
@@ -26,7 +26,8 @@
 
 from numba.rewrites import register_rewrite, Rewrite
 from numba.ir_utils import find_callname, guard, mk_unique_var
-from numba import ir, errors, consts
+from numba import ir, errors
+from numba.core import consts
 
 from sdc.rewrites.ir_utils import remove_unused_recursively, make_assign, find_operations
 

--- a/sdc/str_arr_ext.py
+++ b/sdc/str_arr_ext.py
@@ -44,7 +44,7 @@ from numba.targets.imputils import (impl_ret_new_ref, impl_ret_borrowed, iternex
 from numba.targets.listobj import ListInstance
 from numba.typing.templates import (infer_global, AbstractTemplate, infer,
                                     signature, AttributeTemplate, infer_getattr, bound_function)
-from numba.special import prange
+from numba import prange
 
 from sdc.str_ext import string_type
 from sdc.str_arr_type import (StringArray, string_array_type, StringArrayType,
@@ -109,7 +109,7 @@ class StrArrayIteratorModel(models.StructModel):
         super(StrArrayIteratorModel, self).__init__(dmm, fe_type, members)
 
 
-lower_builtin('getiter', string_array_type)(numba.targets.arrayobj.getiter_array)
+lower_builtin('getiter', string_array_type)(numba.np.arrayobj.getiter_array)
 
 lower_builtin('iternext', StringArrayIterator)(iternext_impl(RefType.NEW)(iternext_str_array))
 

--- a/sdc/tests/test_dataframe.py
+++ b/sdc/tests/test_dataframe.py
@@ -32,9 +32,8 @@ import random
 import string
 import unittest
 from itertools import permutations, product
-from numba import types
-from numba.config import IS_32BITS
-from numba.special import literal_unroll
+from numba.core.config import IS_32BITS
+from numba.misc.special import literal_unroll
 from numba.errors import TypingError
 
 import sdc

--- a/sdc/tests/test_io.py
+++ b/sdc/tests/test_io.py
@@ -31,7 +31,7 @@ import platform
 import pyarrow.parquet as pq
 import unittest
 import numba
-from numba.config import IS_32BITS
+from numba.core.config import IS_32BITS
 from pandas.api.types import CategoricalDtype
 
 import sdc

--- a/sdc/tests/test_series.py
+++ b/sdc/tests/test_series.py
@@ -35,9 +35,9 @@ import string
 import unittest
 from itertools import combinations, combinations_with_replacement, islice, permutations, product
 from numba import types
-from numba.config import IS_32BITS
+from numba.core.config import IS_32BITS
 from numba.errors import TypingError
-from numba.special import literally
+from numba.misc.special import literally
 
 from sdc.tests.test_series_apply import TestSeries_apply
 from sdc.tests.test_series_map import TestSeries_map

--- a/sdc/utilities/utils.py
+++ b/sdc/utilities/utils.py
@@ -31,6 +31,7 @@ from llvmlite import ir as lir
 from collections import namedtuple
 import operator
 import numba
+import numba.datamodel
 from numba import ir_utils, ir, types, cgutils
 from numba.ir_utils import (guard, get_definition, find_callname, require,
                             add_offset_to_labels, find_topo_order, find_const)


### PR DESCRIPTION
This PR eliminates errors caused of absent aliases in Numba 0.49.0rc1 - see https://github.com/numba/numba/issues/5528 for all cases.
After this modification it is possibility to run tests. But tests are not passing. It could be caused by other changes in new Numba version. 

