### PR TITLE
Disable build of sdc.parquet_cpp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -162,8 +162,9 @@ ext_parquet = Extension(name="sdc.parquet_cpp",
 
 _ext_mods = [ext_hdist, ext_chiframes, ext_set, ext_str, ext_dt, ext_io, ext_transport_seq]
 
-if _has_pyarrow:
-    _ext_mods.append(ext_parquet)
+# Support of Parquet is disabled because HPAT pipeline is not work now
+# if _has_pyarrow:
+#     _ext_mods.append(ext_parquet)
 
 
 class style(Command):
@@ -318,7 +319,6 @@ setup(name=SDC_NAME_STR,
           'pyarrow==0.15.1',
           'numba==0.48'
           ],
-      extras_require={'Parquet': ["pyarrow"], },
       cmdclass=sdc_build_commands,
       ext_modules=_ext_mods,
       entry_points={

--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,7 @@ ext_parquet = Extension(name="sdc.parquet_cpp",
 
 _ext_mods = [ext_hdist, ext_chiframes, ext_set, ext_str, ext_dt, ext_io, ext_transport_seq]
 
-# Support of Parquet is disabled because HPAT pipeline is not work now
+# Support of Parquet is disabled because HPAT pipeline does not work now
 # if _has_pyarrow:
 #     _ext_mods.append(ext_parquet)
 


### PR DESCRIPTION
This PR disables building `parquet_cpp` module. Tests are already disabled.
Parquet support is not work because HPAT pipeline is not work.