### PR TITLE
Remove scipy dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ Building on Linux with setuptools
 
     PYVER=<3.6 or 3.7>
     NUMPYVER=<1.16 or 1.17>
-    conda create -n sdc-env -q -y -c intel/label/beta -c defaults -c intel -c conda-forge python=$PYVER numpy=$NUMPYVER numba=0.48.0 pandas=0.25.3 scipy pyarrow=0.15.1 gcc_linux-64 gxx_linux-64
+    conda create -n sdc-env -q -y -c intel/label/beta -c defaults -c intel -c conda-forge python=$PYVER numpy=$NUMPYVER numba=0.48.0 pandas=0.25.3 pyarrow=0.15.1 gcc_linux-64 gxx_linux-64
     source activate sdc-env
     git clone https://github.com/IntelPython/sdc.git
     cd sdc
@@ -126,7 +126,7 @@ Building on Windows with setuptools
 
     set PYVER=<3.6 or 3.7>
     set NUMPYVER=<1.16 or 1.17>
-    conda create -n sdc-env -c intel/label/beta -c defaults -c intel -c conda-forge python=%PYVER% numpy=%NUMPYVER% numba=0.48.0 pandas=0.25.3 scipy pyarrow=0.15.1
+    conda create -n sdc-env -c intel/label/beta -c defaults -c intel -c conda-forge python=%PYVER% numpy=%NUMPYVER% numba=0.48.0 pandas=0.25.3 pyarrow=0.15.1
     conda activate sdc-env
     set INCLUDE=%INCLUDE%;%CONDA_PREFIX%\Library\include
     set LIB=%LIB%;%CONDA_PREFIX%\Library\lib
@@ -156,10 +156,6 @@ Building Intel® SDC User's Guide documentation requires pre-installed Intel® S
 along with compatible `Pandas*`_ version as well as `Sphinx*`_ 2.2.1 or later.
 
 Intel® SDC documentation includes Intel® SDC examples output which is pasted to functions description in the API Reference.
-In order to get the correct examples result it is required to install ``scipy`` package before documentation build:
-::
-
-    conda install scipy -c intel --override-channels
 
 Use ``pip`` to install `Sphinx*`_ and extensions:
 ::
@@ -324,9 +320,6 @@ Developer's Guide and must not be included into User's Guide.
 Running unit tests
 ------------------
 ::
-
-    # Scipy is required for tests
-    conda install -y scipy
 
     python sdc/tests/gen_test_data.py
     python -m unittest

--- a/buildscripts/build_doc.py
+++ b/buildscripts/build_doc.py
@@ -96,7 +96,7 @@ if __name__ == '__main__':
     sdc_utils = SDC_Build_Utilities(args.python, args.sdc_channel)
     sdc_utils.log_info('Build Intel(R) SDC documentation', separate=True)
     sdc_utils.log_info(sdc_utils.line_double)
-    sdc_utils.create_environment(['sphinx', 'sphinxcontrib-programoutput', 'scipy'])
+    sdc_utils.create_environment(['sphinx', 'sphinxcontrib-programoutput'])
     sdc_utils.install_conda_package(['sdc'])
 
     build_doc(sdc_utils)

--- a/buildscripts/run_benchmarks.py
+++ b/buildscripts/run_benchmarks.py
@@ -57,7 +57,7 @@ if __name__ == '__main__':
     sdc_utils = SDC_Build_Utilities(args.python, args.sdc_channel)
     sdc_utils.log_info('Run Intel(R) SDC benchmarks', separate=True)
     sdc_utils.log_info(sdc_utils.line_double)
-    sdc_utils.create_environment(['scipy', 'openpyxl', 'xlrd'])
+    sdc_utils.create_environment(['openpyxl', 'xlrd'])
     sdc_utils.install_conda_package(['sdc'])
 
     run_benchmarks(sdc_utils, args.args_list, args.num_threads_list)

--- a/buildscripts/run_examples.py
+++ b/buildscripts/run_examples.py
@@ -89,7 +89,7 @@ if __name__ == '__main__':
     sdc_utils = SDC_Build_Utilities(args.python, args.sdc_channel)
     sdc_utils.log_info('Run Intel(R) SDC examples', separate=True)
     sdc_utils.log_info(sdc_utils.line_double)
-    sdc_utils.create_environment(['scipy'])
+    sdc_utils.create_environment()
     sdc_utils.install_conda_package(['sdc'])
 
     run_examples(sdc_utils)

--- a/buildscripts/sdc-conda-recipe/meta.yaml
+++ b/buildscripts/sdc-conda-recipe/meta.yaml
@@ -39,8 +39,6 @@ requirements:
     - setuptools
 
 test:
-  requires:
-    - scipy
   imports:
     - sdc
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -168,8 +168,7 @@ todo_link_only = True
 intersphinx_mapping = {
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'python': ('http://docs.python.org/2', None),
-    'numpy': ('http://docs.scipy.org/doc/numpy', None),
-    'scipy': ('http://docs.scipy.org/doc/scipy/reference', None),
+    'numpy': ('http://docs.scipy.org/doc/numpy', None)
 }
 
 # -- Napoleon extension configuration (Numpy and Google docstring options) -------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-scipy
 numpy>=1.16
 pandas==0.25.3
 pyarrow==0.15.1

--- a/setup.py
+++ b/setup.py
@@ -312,7 +312,6 @@ setup(name=SDC_NAME_STR,
       packages=find_packages(),
       package_data={'sdc.tests': ['*.bz2'], },
       install_requires=[
-          'scipy',
           'numpy>=1.16',
           'pandas==0.25.3',
           'pyarrow==0.15.1',


### PR DESCRIPTION
Remove scipy from setup.py, README.txt, and buildscripts
Execute tests and examples locally - it works.

Documentation build fails - the issue is related to incorrect path which appears somewhere during doc build. Denis will take care of this issue.