### PR TITLE
Optimize getitem operations by checking for same indexes

### DIFF
--- a/sdc/datatypes/common_functions.py
+++ b/sdc/datatypes/common_functions.py
@@ -561,7 +561,7 @@ def _sdc_asarray(data):
     pass
 
 
-@sdc_overload(_sdc_asarray, jit_options={'parallel': True})
+@sdc_overload(_sdc_asarray)
 def _sdc_asarray_overload(data):
 
     # TODO: extend with other types
@@ -673,14 +673,21 @@ def sdc_reindex_series(arr, index, name, by_index):
     pass
 
 
-@sdc_overload(sdc_reindex_series, jit_options={'parallel': True})
+@sdc_overload(sdc_reindex_series)
 def sdc_reindex_series_overload(arr, index, name, by_index):
     """ Reindexes series data by new index following the logic of pandas.core.indexing.check_bool_indexer """
 
+    same_index_types = index is by_index
     data_dtype, index_dtype = arr.dtype, index.dtype
     data_is_str_arr = isinstance(arr.dtype, types.UnicodeType)
 
     def sdc_reindex_series_impl(arr, index, name, by_index):
+
+        # if index types are the same, we may not reindex if indexes are the same
+        if same_index_types == True:  # noqa
+            if index is by_index:
+                return pandas.Series(data=arr, index=index, name=name)
+
         if data_is_str_arr == True:  # noqa
             _res_data = [''] * len(by_index)
             res_data_nan_mask = numpy.zeros(len(by_index), dtype=types.bool_)
@@ -722,5 +729,3 @@ def sdc_reindex_series_overload(arr, index, name, by_index):
         return pandas.Series(data=res_data, index=by_index, name=name)
 
     return sdc_reindex_series_impl
-
-    return None

--- a/sdc/datatypes/hpat_pandas_dataframe_functions.py
+++ b/sdc/datatypes/hpat_pandas_dataframe_functions.py
@@ -29,7 +29,6 @@
 | Also, it contains Numba internal operators which are required for DataFrame type handling
 '''
 
-
 import numba
 import numpy
 import operator
@@ -65,6 +64,7 @@ from sdc.hiframes.api import isna
 from sdc.functions.numpy_like import getitem_by_mask
 from sdc.datatypes.common_functions import _sdc_take, sdc_reindex_series
 from sdc.utilities.prange_utils import parallel_chunks
+
 
 @sdc_overload_attribute(DataFrameType, 'index')
 def hpat_pandas_dataframe_index(df):
@@ -105,6 +105,7 @@ def hpat_pandas_dataframe_index(df):
 
         return hpat_pandas_df_index_none_impl
     else:
+
         def hpat_pandas_df_index_impl(df):
             return df._index
 
@@ -403,7 +404,6 @@ def sdc_pandas_dataframe_append(df, other, ignore_index=False, verify_integrity=
         return _append_impl
 
     return sdc_pandas_dataframe_append_impl(df, other, _func_name, ignore_index, indexes_comparable, args)
-
 
 # Example func_text for func_name='count' columns=('A', 'B'):
 #
@@ -1534,9 +1534,9 @@ def df_getitem_bool_series_idx_main_codelines(self, idx):
     else:
         func_lines = [f'  length = {df_length_expr(self)}',
                       f'  self_index = self.index',
-                      f'  idx_reindexed = sdc_reindex_series(idx._data, idx.index, idx._name, self_index)',
-                      f'  res_index = getitem_by_mask(self_index, idx_reindexed._data)',
-                      f'  selected_pos = getitem_by_mask(range(length), idx_reindexed._data)']
+                      f'  reindexed_idx = sdc_reindex_series(idx._data, idx.index, idx._name, self_index)',
+                      f'  res_index = getitem_by_mask(self_index, reindexed_idx._data)',
+                      f'  selected_pos = getitem_by_mask(numpy.arange(length), reindexed_idx._data)']
 
         results = []
         for i, col in enumerate(self.columns):
@@ -1835,6 +1835,7 @@ def sdc_pandas_dataframe_getitem(self, idx):
         return _df_getitem_str_literal_idx_impl
 
     if isinstance(idx, types.UnicodeType):
+
         def _df_getitem_unicode_idx_impl(self, idx):
             # http://numba.pydata.org/numba-doc/dev/developer/literal.html#specifying-for-literal-typing
             # literally raises special exception to call getitem with literal idx value got from unicode
@@ -1886,6 +1887,7 @@ def sdc_pandas_dataframe_accessor_getitem(self, idx):
         if isinstance(idx, types.Tuple) and isinstance(idx[1], types.Literal):
             col = idx[1].literal_value
             if -1 < col < len(self.dataframe.columns):
+
                 def df_getitem_iat_tuple_impl(self, idx):
                     row, _ = idx
                     if -1 < row < len(self._dataframe.index):
@@ -2335,6 +2337,7 @@ def df_set_column_overload(self, key, value):
             return gen_df_replace_column_impl(self, key)
 
     if isinstance(key, types.UnicodeType):
+
         def _df_set_column_unicode_key_impl(self, key, value):
             # http://numba.pydata.org/numba-doc/dev/developer/literal.html#specifying-for-literal-typing
             # literally raises special exception to call df._set_column with literal idx value got from unicode

--- a/sdc/str_arr_ext.py
+++ b/sdc/str_arr_ext.py
@@ -1543,3 +1543,14 @@ def sdc_str_arr_operator_mul(self, other):
         return res_arr
 
     return _sdc_str_arr_operator_mul_impl
+
+
+@lower_builtin(operator.is_, StringArrayType, StringArrayType)
+def sdc_str_arr_operator_is(context, builder, sig, args):
+
+    # meminfo ptr uniquely identifies each StringArray allocation
+    a = context.make_helper(builder, string_array_type, args[0])
+    b = context.make_helper(builder, string_array_type, args[1])
+    ma = builder.ptrtoint(a.meminfo, cgutils.intp_t)
+    mb = builder.ptrtoint(b.meminfo, cgutils.intp_t)
+    return builder.icmp_signed('==', ma, mb)

--- a/sdc/tests/test_series.py
+++ b/sdc/tests/test_series.py
@@ -6985,6 +6985,31 @@ class TestSeries(
         self.assertIn(str(sdc_exception), str(pandas_exception))
 
     @skip_sdc_jit('Not implemented in old-pipeline')
+    def test_series_getitem_idx_bool_series3(self):
+        """ Verifies Series.getitem by mask indicated by a Boolean Series with the same object as index """
+        def test_impl(A, mask, index):
+            S = pd.Series(A, index)
+            idx = pd.Series(mask, S.index)
+            return S[idx]
+        hpat_func = self.jit(test_impl)
+
+        n = 11
+        np.random.seed(0)
+
+        idxs_to_test = [
+            np.arange(n),
+            np.arange(n, dtype='float'),
+            gen_strlist(n, 2, 'abcd123 ')
+        ]
+        series_data = np.arange(n)
+        mask = np.random.choice([True, False], n)
+        for index in idxs_to_test:
+            with self.subTest(series_index=index):
+                result = hpat_func(series_data, mask, index)
+                result_ref = test_impl(series_data, mask, index)
+                pd.testing.assert_series_equal(result, result_ref)
+
+    @skip_sdc_jit('Not implemented in old-pipeline')
     def test_series_getitem_idx_bool_series_reindex(self):
         """ Verifies Series.getitem with reindexing by mask indicated by a Boolean Series
         on Series with various types of indexes """

--- a/sdc/tests/tests_perf/test_perf_df.py
+++ b/sdc/tests/tests_perf/test_perf_df.py
@@ -36,7 +36,7 @@ from sdc.tests.tests_perf.test_perf_utils import calc_compilation, get_times, pe
 from sdc.tests.test_utils import test_global_input_data_float64
 from .generator import generate_test_cases
 from .generator import TestCase as TC
-from .data_generator import gen_df, gen_series, gen_arr_of_dtype
+from .data_generator import gen_df, gen_series, gen_arr_of_dtype, gen_unique_values
 
 
 # python -m sdc.runtests sdc.tests.tests_perf.test_perf_df.TestDataFrameMethods.test_df_{method_name}
@@ -88,6 +88,8 @@ cases = [
     TC(name='getitem_idx_bool_array', size=[10 ** 7], call_expr='df[idx]', usecase_params='df, idx',
        data_gens=(gen_df, partial(gen_arr_of_dtype, dtype='bool', random=False)),
        input_data=[None, [True, False, False, True, False, True]]),
+    TC(name='getitem_filter_by_value', size=[10 ** 7], call_expr='df[df.A > 0]', usecase_params='df',
+       data_gens=(partial(gen_df, index_gen=gen_unique_values), )),
 ]
 
 generate_test_cases(cases, TestDataFrameMethods, 'df')


### PR DESCRIPTION
Some performance results (from laptop):

**with fix:**
  |   |   |   | median | min | max | compile | boxing
-- | -- | -- | -- | -- | -- | -- | -- | --
name | nthreads | type | size |   |   |   |   |  
DataFrame.getitem_filter_by_value | 1 | Python | 10000000 | 0.328003 | 0.318 | 0.357003 | NaN | NaN
  |   | SDC | 10000000 | 0.34 | 0.287 | 0.404 | 0.715081 | 1.126521
  | 2 | SDC | 10000000 | 0.205 | 0.194 | 0.243 | 0.666005 | 0.958931
  | 4 | SDC | 10000000 | 0.154 | 0.128 | 0.176 | 0.616491 | 0.935159

**without fix (on master):**
  |   |   |   | median | min | max | compile | boxing
-- | -- | -- | -- | -- | -- | -- | -- | --
name | nthreads | type | size |   |   |   |   |  
DataFrame.getitem_filter_by_value | 1 | Python | 10000000 | 0.314004 | 0.311996 | 0.318 | NaN | NaN
  |   | SDC | 10000000 | 3.748 | 3.618 | 4.133 | 0.731427 | 0.853143
  | 2 | SDC | 10000000 | 3.158 | 3.113 | 3.632 | 0.78739 | 0.859766
  | 4 | SDC | 10000000 | 3.06 | 3.007 | 3.454 | 0.813918 | 0.958313

For some reason on nnlmlp01 (but not on ansatclx1004 and my laptop) SDC is slower than python by 2 times on single thread (on the same test). This needs to be investigated further.
**with fix on nnlmlp01:**
  |   |   |   | median | min | max | compile | boxing
-- | -- | -- | -- | -- | -- | -- | -- | --
name | nthreads | type | size |   |   |   |   |  
DataFrame.getitem_filter_by_value | 1 | Python | 10000000 | 0.268062 | 0.267576 | 0.270783 | NaN | NaN
  |   | SDC | 10000000 | 0.361877 | 0.361485 | 0.362171 | 0.612621 | 1.002072
  | 2 | SDC | 10000000 | 0.213841 | 0.212518 | 0.215923 | 0.672137 | 1.019482
  | 4 | SDC | 10000000 | 0.120625 | 0.11833 | 0.125019 | 0.622494 | 1.026524
  | 8 | SDC | 10000000 | 0.075155 | 0.074595 | 0.075756 | 0.624533 | 1.027116
  | 16 | SDC | 10000000 | 0.059031 | 0.058086 | 0.075269 | 0.612236 | 1.051869
  | 28 | SDC | 10000000 | 0.054463 | 0.051837 | 0.056121 | 0.608134 | 1.074058
  | 56 | SDC | 10000000 | 0.060003 | 0.056724 | 0.062026 | 0.644352 | 1.094665

