### PR TITLE
Added environment.yml file for quick create development environment in conda

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -149,6 +149,13 @@ Troubleshooting Windows Build
   building Intel® SDC can throw some vague error about a keyword used in a file.
   So make sure you are using the latest versions.
 
+Create Development Environment
+------------------------------
+
+::
+
+    conda env create -n sdc-dev-env -f environment.yml
+
 Building documentation
 ----------------------
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,19 @@
+channels:
+  - numba
+  - defaults
+dependencies:
+  - python=3.7
+  - numba=0.48.0
+  - pandas=0.25.3
+  - pyarrow=0.15.1
+  - scipy=1.4.1
+  - mpich=3.3.2
+  - gcc_linux-64=7.3.0
+  - gxx_linux-64=7.3.0
+
+  - pycodestyle
+  - pytest
+  - pytest-xdist
+  - sphinx
+  - pip:
+    - sphinxcontrib-programoutput


### PR DESCRIPTION
Tested only on Linux.
README updated.
Usage: `conda env create -n sdc-env -f environment.yml`