### PR TITLE
Refactor imports from Numba

### DIFF
--- a/sdc/__init__.py
+++ b/sdc/__init__.py
@@ -57,8 +57,8 @@ if not sdc.config.config_pipeline_hpat_default:
     """
 
     # sdc.config.numba_compiler_define_nopython_pipeline_orig = \
-    # numba.compiler.DefaultPassBuilder.define_nopython_pipeline
-    # numba.compiler.DefaultPassBuilder.define_nopython_pipeline = \
+    # numba.core.compiler.DefaultPassBuilder.define_nopython_pipeline
+    # numba.core.compiler.DefaultPassBuilder.define_nopython_pipeline = \
     # sdc.datatypes.hpat_pandas_dataframe_pass.sdc_nopython_pipeline_lite_register
 
     import sdc.rewrites.dataframe_constructor

--- a/sdc/compiler.py
+++ b/sdc/compiler.py
@@ -34,18 +34,18 @@ from sdc.hiframes.hiframes_untyped import HiFramesPass
 from sdc.hiframes.hiframes_typed import HiFramesTypedPass
 from sdc.hiframes.dataframe_pass import DataFramePass
 import numba
-import numba.compiler
-from numba.compiler import DefaultPassBuilder
+import numba.core.compiler
+from numba.core.compiler import DefaultPassBuilder
 from numba import ir_utils, ir, postproc
-from numba.targets.registry import CPUDispatcher
-from numba.ir_utils import guard, get_definition
-from numba.inline_closurecall import inline_closure_call
+from numba.core.registry import CPUDispatcher
+from numba.core.ir_utils import guard, get_definition
+from numba.core.inline_closurecall import inline_closure_call
 from numba.typed_passes import (NopythonTypeInference, AnnotateTypes, ParforPass, IRLegalization)
 from numba.untyped_passes import (DeadBranchPrune, InlineInlinables, InlineClosureLikes)
 from sdc import config
 from sdc.distributed import DistributedPass
 
-from numba.compiler_machinery import FunctionPass, register_pass
+from numba.core.compiler_machinery import FunctionPass, register_pass
 
 # workaround for Numba #3876 issue with large labels in mortgage benchmark
 binding.set_option("tmp", "-non-global-value-max-name-size=2048")
@@ -143,7 +143,7 @@ class PostprocessorPass(FunctionPass):
         return True
 
 
-class SDCPipeline(numba.compiler.CompilerBase):
+class SDCPipeline(numba.core.compiler.CompilerBase):
     """SDC compiler pipeline
     """
 
@@ -170,7 +170,7 @@ class ParforSeqPass(FunctionPass):
         pass
 
     def run_pass(self, state):
-        numba.parfor.lower_parfor_sequential(
+        numba.parfors.parfor.lower_parfor_sequential(
             state.typingctx, state.func_ir, state.typemap, state.calltypes)
 
         return True

--- a/sdc/cv_ext.py
+++ b/sdc/cv_ext.py
@@ -28,12 +28,12 @@
 import numba
 import sdc
 from numba import types
-from numba.typing.templates import infer_global, AbstractTemplate, infer, signature
+from numba.core.typing.templates import infer_global, AbstractTemplate, infer, signature
 from numba.extending import lower_builtin, overload, intrinsic
-from numba import cgutils
+from numba.core import cgutils
 from sdc.str_ext import string_type
-from numba.targets.imputils import impl_ret_new_ref, impl_ret_borrowed
-from numba.targets.arrayobj import _empty_nd_impl
+from numba.core.imputils import impl_ret_new_ref, impl_ret_borrowed
+from numba.np.arrayobj import _empty_nd_impl
 
 import cv2
 import numpy as np

--- a/sdc/datatypes/common_functions.py
+++ b/sdc/datatypes/common_functions.py
@@ -35,11 +35,11 @@ import pandas
 from pandas.core.indexing import IndexingError
 
 import numba
-from numba.targets import quicksort
+from numba.misc import quicksort
 from numba import types
-from numba.errors import TypingError
+from numba.core.errors import TypingError
 from numba.extending import register_jitable
-from numba import numpy_support
+from numba.np import numpy_support
 from numba.typed import Dict
 
 import sdc

--- a/sdc/datatypes/hpat_pandas_dataframe_functions.py
+++ b/sdc/datatypes/hpat_pandas_dataframe_functions.py
@@ -38,9 +38,9 @@ import sdc
 from pandas.core.indexing import IndexingError
 
 from numba import types
-from numba.special import literally
+from numba import literally
 from numba.typed import List, Dict
-from numba.errors import TypingError
+from numba.core.errors import TypingError
 from pandas.core.indexing import IndexingError
 
 from sdc.hiframes.pd_dataframe_ext import DataFrameType

--- a/sdc/datatypes/hpat_pandas_dataframe_getitem_types.py
+++ b/sdc/datatypes/hpat_pandas_dataframe_getitem_types.py
@@ -27,10 +27,11 @@
 
 import pandas
 
-from numba import types, cgutils
+from numba import types
+from numba.core import cgutils
 from numba.extending import models, overload, register_model, make_attribute_wrapper, intrinsic
-from numba.datamodel import register_default, StructModel
-from numba.typing.templates import signature
+from numba.core.datamodel import register_default, StructModel
+from numba.core.typing.templates import signature
 
 
 class DataFrameGetitemAccessorType(types.Type):

--- a/sdc/datatypes/hpat_pandas_dataframe_pass.py
+++ b/sdc/datatypes/hpat_pandas_dataframe_pass.py
@@ -33,8 +33,8 @@ import pandas
 
 import numba
 from numba import ir, types
-from numba.compiler_machinery import FunctionPass, register_pass
-from numba.ir_utils import find_topo_order, build_definitions, guard, find_callname
+from numba.core.compiler_machinery import FunctionPass, register_pass
+from numba.core.ir_utils import find_topo_order, build_definitions, guard, find_callname
 
 import sdc
 
@@ -82,7 +82,7 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage2(FunctionPass):
                     inst.value = ir.Expr.call(ir.Var(block.scope, "dummy", inst.loc), rp_func.args, (), inst.loc)
                     block.body = new_body + block.body[i:]
                     sdc.utilities.utils.update_globals(rp_func.func, rp_func.glbls)
-                    numba.inline_closurecall.inline_closure_call(self.state.func_ir,
+                    numba.core.inline_closurecall.inline_closure_call(self.state.func_ir,
                                                                  rp_func.glbls,
                                                                  block,
                                                                  len(new_body),
@@ -104,15 +104,15 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage2(FunctionPass):
                 blocks[label].body = new_body
 
         # XXX remove slice() of h5 read due to Numba's #3380 bug
-        self.state.func_ir.blocks = numba.ir_utils.simplify_CFG(self.state.func_ir.blocks)
-        while numba.ir_utils.remove_dead(self.state.func_ir.blocks,
+        self.state.func_ir.blocks = numba.core.ir_utils.simplify_CFG(self.state.func_ir.blocks)
+        while numba.core.ir_utils.remove_dead(self.state.func_ir.blocks,
                                          self.state.func_ir.arg_names,
                                          self.state.func_ir,
                                          self.state.typemap):
             pass
 
         self.state.func_ir._definitions = build_definitions(self.state.func_ir.blocks)
-        numba.ir_utils.dprint_func_ir(self.state.func_ir, self._name)
+        numba.core.ir_utils.dprint_func_ir(self.state.func_ir, self._name)
 
         return True
 
@@ -176,12 +176,12 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage2(FunctionPass):
             data, other = rhs.args
 
             def _isin_series(A, B):
-                numba.parfor.init_prange()
+                numba.parfors.parfor.init_prange()
                 n = len(A)
                 m = len(B)
                 S = numpy.empty(n, numpy.bool_)
 
-                for i in numba.parfor.internal_prange(n):
+                for i in numba.parfors.parfor.internal_prange(n):
                     S[i] = (A[i] == B[i] if i < m else False)
 
                 return S
@@ -193,11 +193,11 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage2(FunctionPass):
             data = rhs.args[0]
 
             def _isin_series(A, vals):
-                numba.parfor.init_prange()
+                numba.parfors.parfor.init_prange()
                 n = len(A)
                 S = numpy.empty(n, numpy.bool_)
 
-                for i in numba.parfor.internal_prange(n):
+                for i in numba.parfors.parfor.internal_prange(n):
                     S[i] = A[i] in vals
 
                 return S
@@ -221,7 +221,7 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage2(FunctionPass):
         return self._replace_func(sdc.hiframes.series_kernels._column_filter_impl, [in_arr, bool_arr], pre_nodes=nodes)
 
     def _get_series_data(self, series_var, nodes):
-        var_def = guard(numba.ir_utils.get_definition, self.state.func_ir, series_var)
+        var_def = guard(numba.core.ir_utils.get_definition, self.state.func_ir, series_var)
         call_def = guard(find_callname, self.state.func_ir, var_def)
 
         if call_def == ('init_series', 'sdc.hiframes.api'):
@@ -230,13 +230,13 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage2(FunctionPass):
         def _get_series_data_lambda(S):
             return sdc.hiframes.api.get_series_data(S)
 
-        f_block = numba.ir_utils.compile_to_numba_ir(_get_series_data_lambda,
+        f_block = numba.core.ir_utils.compile_to_numba_ir(_get_series_data_lambda,
                                                      {'sdc': sdc},
                                                      self.state.typingctx,
                                                      (self.state.typemap[series_var.name], ),
                                                      self.state.typemap,
                                                      self.state.calltypes).blocks.popitem()[1]
-        numba.ir_utils.replace_arg_nodes(f_block, [series_var])
+        numba.core.ir_utils.replace_arg_nodes(f_block, [series_var])
         nodes += f_block.body[:-2]
         return nodes[-1].target
 
@@ -254,14 +254,14 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage2(FunctionPass):
                 return default
 
             def default_handler(index, param, default):
-                d_var = ir.Var(scope, numba.ir_utils.mk_unique_var('defaults'), loc)
+                d_var = ir.Var(scope, numba.core.ir_utils.mk_unique_var('defaults'), loc)
                 self.state.typemap[d_var.name] = numba.typeof(default)
                 node = ir.Assign(ir.Const(default, loc), d_var, loc)
                 pre_nodes.append(node)
 
                 return d_var
 
-            args = numba.typing.fold_arguments(pysig, args, kws, normal_handler, default_handler, normal_handler)
+            args = numba.core.typing.fold_arguments(pysig, args, kws, normal_handler, default_handler, normal_handler)
 
         arg_typs = tuple(self.state.typemap[v.name] for v in args)
 
@@ -269,7 +269,7 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage2(FunctionPass):
             new_args = []
 
             for i, arg in enumerate(args):
-                val = guard(numba.ir_utils.find_const, self.state.func_ir, arg)
+                val = guard(numba.core.ir_utils.find_const, self.state.func_ir, arg)
                 if val:
                     new_args.append(types.literal(val))
                 else:
@@ -308,11 +308,11 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
         # df_var -> label where it is defined
         self.df_labels = {}
 
-        numba.ir_utils._max_label = max(self.state.func_ir.blocks.keys()) # shssf:  is it still needed?
+        numba.core.ir_utils._max_label = max(self.state.func_ir.blocks.keys()) # shssf:  is it still needed?
 
         # FIXME: see why this breaks test_kmeans
         # remove_dels(self.state.func_ir.blocks)
-        numba.ir_utils.dprint_func_ir(self.state.func_ir, self._name)
+        numba.core.ir_utils.dprint_func_ir(self.state.func_ir, self._name)
         blocks = self.state.func_ir.blocks
         # call build definition since rewrite pass doesn't update definitions
         # e.g. getitem to static_getitem in test_column_list_select2
@@ -334,7 +334,7 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
                 if (isinstance(inst, ir.StaticSetItem)
                         and isinstance(inst.index, str)):
                     # cfg needed for set df column
-                    cfg = numba.ir_utils.compute_cfg_from_blocks(blocks)
+                    cfg = numba.core.ir_utils.compute_cfg_from_blocks(blocks)
                     out_nodes = self._run_df_set_column(inst, label, cfg)
                 elif isinstance(inst, ir.Assign):
                     self.state.func_ir._definitions[inst.target.name].remove(inst.value)
@@ -350,14 +350,14 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
                         new_body.extend(rp_func.pre_nodes)
                         self._update_definitions(rp_func.pre_nodes)
                     # replace inst.value to a call with target args
-                    # as expected by numba.inline_closurecall.inline_closure_call
+                    # as expected by numba.core.inline_closurecall.inline_closure_call
                     # TODO: inst other than Assign?
                     inst.value = ir.Expr.call(
                         ir.Var(block.scope, "dummy", inst.loc),
                         rp_func.args, (), inst.loc)
                     block.body = new_body + block.body[i:]
                     sdc.utilities.utils.update_globals(rp_func.func, rp_func.glbls)
-                    numba.inline_closurecall.inline_closure_call(self.state.func_ir, rp_func.glbls,
+                    numba.core.inline_closurecall.inline_closure_call(self.state.func_ir, rp_func.glbls,
                                         block, len(new_body), rp_func.func, work_list=work_list)
                     replaced = True
                     break
@@ -373,14 +373,14 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
             if not replaced:
                 blocks[label].body = new_body
 
-        self.state.func_ir.blocks = numba.ir_utils.simplify_CFG(self.state.func_ir.blocks)
+        self.state.func_ir.blocks = numba.core.ir_utils.simplify_CFG(self.state.func_ir.blocks)
         # self.state.func_ir._definitions = build_definitions(blocks)
         # XXX: remove dead here fixes h5 slice issue
         # iterative remove dead to make sure all extra code (e.g. df vars) is removed
         # while remove_dead(blocks, self.state.func_ir.arg_names, self.state.func_ir):
         #     pass
         self.state.func_ir._definitions = build_definitions(blocks)
-        numba.ir_utils.dprint_func_ir(self.state.func_ir, self._name)
+        numba.core.ir_utils.dprint_func_ir(self.state.func_ir, self._name)
 
         return True
 
@@ -391,7 +391,7 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
             lhs = inst.target.name
             self.state.func_ir._definitions[lhs].remove(inst.value)
 
-        numba.ir_utils.replace_vars_stmt(inst, self.replace_var_dict)
+        numba.core.ir_utils.replace_vars_stmt(inst, self.replace_var_dict)
 
         if sdc.utilities.utils.is_assign(inst):
             self.state.func_ir._definitions[lhs].append(inst.value)
@@ -410,7 +410,7 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
             # HACK: delete pd.DataFrame({}) nodes to avoid typing errors
             # TODO: remove when dictionaries are implemented and typing works
             if rhs.op == 'getattr':
-                val_def = guard(numba.ir_utils.get_definition, self.state.func_ir, rhs.value)
+                val_def = guard(numba.core.ir_utils.get_definition, self.state.func_ir, rhs.value)
                 if (isinstance(val_def, ir.Global) and val_def.value == pandas and rhs.attr in ('DataFrame', 'read_csv', 'read_parquet', 'to_numeric')):
                     # TODO: implement to_numeric in typed pass?
                     # put back the definition removed earlier but remove node
@@ -419,7 +419,7 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
                     return []
 
             if rhs.op == 'getattr':
-                val_def = guard(numba.ir_utils.get_definition, self.state.func_ir, rhs.value)
+                val_def = guard(numba.core.ir_utils.get_definition, self.state.func_ir, rhs.value)
                 if (isinstance(val_def, ir.Global) and val_def.value == numpy and rhs.attr == 'fromfile'):
                     # put back the definition removed earlier but remove node
                     self.state.func_ir._definitions[lhs].append(rhs)
@@ -508,11 +508,11 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
                 if cname in arg_df_map:
                     other_colmap[cname] = arg_df_map[cname]
         else:
-            other_def = guard(numba.ir_utils.get_definition, self.state.func_ir, other)
+            other_def = guard(numba.core.ir_utils.get_definition, self.state.func_ir, other)
             # dict case
             if isinstance(other_def, ir.Expr) and other_def.op == 'build_map':
                 for c, v in other_def.items:
-                    cname = guard(numba.ir_utils.find_const, self.state.func_ir, c)
+                    cname = guard(numba.core.ir_utils.find_const, self.state.func_ir, c)
                     if not isinstance(cname, str):
                         raise ValueError("dictionary argument to isin() should have constant keys")
                     other_colmap[cname] = v
@@ -534,11 +534,11 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
             data, other = rhs.args
 
             def _isin_series(A, B):
-                numba.parfor.init_prange()
+                numba.parfors.parfor.init_prange()
                 n = len(A)
                 m = len(B)
                 S = numpy.empty(n, np.bool_)
-                for i in numba.parfor.internal_prange(n):
+                for i in numba.parfors.parfor.internal_prange(n):
                     S[i] = (A[i] == B[i] if i < m else False)
                 return S
 
@@ -564,8 +564,8 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
             else:
                 func = bool_arr_func
                 args = false_arr_args
-            f_block = numba.ir_utils.compile_to_numba_ir(func, {'sdc': sdc, 'numpy': numpy}).blocks.popitem()[1]
-            numba.ir_utils.replace_arg_nodes(f_block, args)
+            f_block = numba.core.ir_utils.compile_to_numba_ir(func, {'sdc': sdc, 'numpy': numpy}).blocks.popitem()[1]
+            numba.core.ir_utils.replace_arg_nodes(f_block, args)
             nodes += f_block.body[:-2]
             out_df_map[cname] = nodes[-1].target
 
@@ -581,14 +581,14 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
         if self._is_df_var(other):
             return self._handle_concat_df(lhs, [df_var, other], label)
         # list of dfs
-        df_list = guard(numba.ir_utils.get_definition, self.state.func_ir, other)
+        df_list = guard(numba.core.ir_utils.get_definition, self.state.func_ir, other)
         if len(df_list.items) > 0 and self._is_df_var(df_list.items[0]):
             return self._handle_concat_df(lhs, [df_var] + df_list.items, label)
         raise ValueError("invalid df.append() input. Only dataframe and list of dataframes supported")
 
     def _handle_df_fillna(self, lhs, rhs, df_var, label):
         nodes = []
-        inplace_default = ir.Var(lhs.scope, numba.ir_utils.mk_unique_var("fillna_default"), lhs.loc)
+        inplace_default = ir.Var(lhs.scope, numba.core.ir_utils.mk_unique_var("fillna_default"), lhs.loc)
         nodes.append(ir.Assign(ir.Const(False, lhs.loc), inplace_default, lhs.loc))
         val_var = self._get_arg('fillna', rhs.args, dict(rhs.kws), 0, 'value')
         inplace_var = self._get_arg('fillna', rhs.args, dict(rhs.kws), 3, 'inplace', default=inplace_default)
@@ -598,26 +598,26 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
 
         out_col_map = {}
         for cname, in_var in self._get_df_cols(df_var).items():
-            f_block = numba.ir_utils.compile_to_numba_ir(_fillna_func, {}).blocks.popitem()[1]
-            numba.ir_utils.replace_arg_nodes(f_block, [in_var, val_var, inplace_var])
+            f_block = numba.core.ir_utils.compile_to_numba_ir(_fillna_func, {}).blocks.popitem()[1]
+            numba.core.ir_utils.replace_arg_nodes(f_block, [in_var, val_var, inplace_var])
             nodes += f_block.body[:-2]
             out_col_map[cname] = nodes[-1].target
 
         # create output df if not inplace
-        if (inplace_var.name == inplace_default.name or guard(numba.ir_utils.find_const, self.state.func_ir, inplace_var) == False):
+        if (inplace_var.name == inplace_default.name or guard(numba.core.ir_utils.find_const, self.state.func_ir, inplace_var) == False):
             self._create_df(lhs.name, out_col_map, label)
         return nodes
 
     def _handle_df_dropna(self, lhs, rhs, df_var, label):
         nodes = []
-        inplace_default = ir.Var(lhs.scope, numba.ir_utils.mk_unique_var("dropna_default"), lhs.loc)
+        inplace_default = ir.Var(lhs.scope, numba.core.ir_utils.mk_unique_var("dropna_default"), lhs.loc)
         nodes.append(ir.Assign(ir.Const(False, lhs.loc), inplace_default, lhs.loc))
         inplace_var = self._get_arg('dropna', rhs.args, dict(rhs.kws), 4, 'inplace', default=inplace_default)
 
         col_names = self._get_df_col_names(df_var)
         col_vars = self._get_df_col_vars(df_var)
-        arg_names = ", ".join([numba.ir_utils.mk_unique_var(cname).replace('.', '_') for cname in col_names])
-        out_names = ", ".join([numba.ir_utils.mk_unique_var(cname).replace('.', '_') for cname in col_names])
+        arg_names = ", ".join([numba.core.ir_utils.mk_unique_var(cname).replace('.', '_') for cname in col_names])
+        out_names = ", ".join([numba.core.ir_utils.mk_unique_var(cname).replace('.', '_') for cname in col_names])
 
         func_text = "def _dropna_imp({}, inplace):\n".format(arg_names)
         func_text += "  ({},) = sdc.hiframes.api.dropna(({},), inplace)\n".format(
@@ -626,8 +626,8 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
         exec(func_text, {'sdc': sdc}, loc_vars)
         _dropna_imp = loc_vars['_dropna_imp']
 
-        f_block = numba.ir_utils.compile_to_numba_ir(_dropna_imp, {'sdc': sdc}).blocks.popitem()[1]
-        numba.ir_utils.replace_arg_nodes(f_block, col_vars + [inplace_var])
+        f_block = numba.core.ir_utils.compile_to_numba_ir(_dropna_imp, {'sdc': sdc}).blocks.popitem()[1]
+        numba.core.ir_utils.replace_arg_nodes(f_block, col_vars + [inplace_var])
         nodes += f_block.body[:-3]
 
         # extract column vars from output
@@ -636,7 +636,7 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
             out_col_map[cname] = nodes[-len(col_names) + i].target
 
         # create output df if not inplace
-        if (inplace_var.name == inplace_default.name or guard(numba.ir_utils.find_const, self.state.func_ir, inplace_var) == False):
+        if (inplace_var.name == inplace_default.name or guard(numba.core.ir_utils.find_const, self.state.func_ir, inplace_var) == False):
             self._create_df(lhs.name, out_col_map, label)
         else:
             # assign back to column vars for inplace case
@@ -653,23 +653,23 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
         """
         kws = dict(rhs.kws)
         inplace_var = self._get_arg('drop', rhs.args, kws, 5, 'inplace', '')
-        inplace = guard(numba.ir_utils.find_const, self.state.func_ir, inplace_var)
+        inplace = guard(numba.core.ir_utils.find_const, self.state.func_ir, inplace_var)
         if inplace is not None and inplace:
             # TODO: make sure call post dominates df_var definition or df_var
             # is not used in other code paths
             # replace func variable with drop_inplace
-            f_block = numba.ir_utils.compile_to_numba_ir(lambda: sdc.hiframes.api.drop_inplace, {'sdc': sdc}).blocks.popitem()[1]
+            f_block = numba.core.ir_utils.compile_to_numba_ir(lambda: sdc.hiframes.api.drop_inplace, {'sdc': sdc}).blocks.popitem()[1]
             nodes = f_block.body[:-2]
             new_func_var = nodes[-1].target
             rhs.func = new_func_var
             rhs.args.insert(0, df_var)
             # new tuple return
-            ret_tup = ir.Var(lhs.scope, numba.ir_utils.mk_unique_var('drop_ret'), lhs.loc)
+            ret_tup = ir.Var(lhs.scope, numba.core.ir_utils.mk_unique_var('drop_ret'), lhs.loc)
             assign.target = ret_tup
             nodes.append(assign)
-            new_df_var = ir.Var(df_var.scope, numba.ir_utils.mk_unique_var(df_var.name), df_var.loc)
-            zero_var = ir.Var(df_var.scope, numba.ir_utils.mk_unique_var('zero'), df_var.loc)
-            one_var = ir.Var(df_var.scope, numba.ir_utils.mk_unique_var('one'), df_var.loc)
+            new_df_var = ir.Var(df_var.scope, numba.core.ir_utils.mk_unique_var(df_var.name), df_var.loc)
+            zero_var = ir.Var(df_var.scope, numba.core.ir_utils.mk_unique_var('zero'), df_var.loc)
+            one_var = ir.Var(df_var.scope, numba.core.ir_utils.mk_unique_var('one'), df_var.loc)
             nodes.append(ir.Assign(ir.Const(0, lhs.loc), zero_var, lhs.loc))
             nodes.append(ir.Assign(ir.Const(1, lhs.loc), one_var, lhs.loc))
             getitem0 = ir.Expr.static_getitem(ret_tup, 0, zero_var, lhs.loc)
@@ -687,7 +687,7 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
         labels_var = self._get_arg('drop', rhs.args, kws, 0, 'labels', '')
         axis_var = self._get_arg('drop', rhs.args, kws, 1, 'axis', '')
         labels = self._get_str_or_list(labels_var, default='')
-        axis = guard(numba.ir_utils.find_const, self.state.func_ir, axis_var)
+        axis = guard(numba.core.ir_utils.find_const, self.state.func_ir, axis_var)
 
         if labels != '' and axis is not None:
             if axis != 1:
@@ -700,11 +700,11 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
             columns = self._get_str_or_list(columns_var, err_msg=err_msg)
 
         inplace_var = self._get_arg('drop', rhs.args, kws, 5, 'inplace', '')
-        inplace = guard(numba.ir_utils.find_const, self.state.func_ir, inplace_var)
+        inplace = guard(numba.core.ir_utils.find_const, self.state.func_ir, inplace_var)
 
         if inplace is not None and inplace:
             df_label = self.df_labels[df_var.name]
-            cfg = numba.ir_utils.compute_cfg_from_blocks(self.state.func_ir.blocks)
+            cfg = numba.core.ir_utils.compute_cfg_from_blocks(self.state.func_ir.blocks)
             # dropping columns inplace possible only when it dominates the df
             # creation to keep schema consistent
             if label not in cfg.backbone() and label not in cfg.post_dominators()[df_label]:
@@ -739,7 +739,7 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
                     "data argument in pd.DataFrame() expected")
             data = rhs.args[0]
 
-        arg_def = guard(numba.ir_utils.get_definition, self.state.func_ir, data)
+        arg_def = guard(numba.core.ir_utils.get_definition, self.state.func_ir, data)
         if (not isinstance(arg_def, ir.Expr) or arg_def.op != 'build_map'):
             raise ValueError("Invalid DataFrame() arguments (constant dict of columns expected)")
 
@@ -760,7 +760,7 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
         _init_df = loc_vars['_init_df']
 
         # TODO: support index var
-        index = ir.Var(lhs.scope, numba.ir_utils.mk_unique_var('df_index_none'), lhs.loc)
+        index = ir.Var(lhs.scope, numba.core.ir_utils.mk_unique_var('df_index_none'), lhs.loc)
         nodes.append(ir.Assign(ir.Const(None, lhs.loc), index, lhs.loc))
         data_vars = [a[1] for a in items]
         col_vars = [a[0] for a in items]
@@ -771,7 +771,7 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
     def _get_csv_col_info(self, dtype_map, date_cols, col_names, lhs):
         if isinstance(dtype_map, types.Type):
             typ = dtype_map
-            data_arrs = [ir.Var(lhs.scope, numba.ir_utils.mk_unique_var(cname), lhs.loc)
+            data_arrs = [ir.Var(lhs.scope, numba.core.ir_utils.mk_unique_var(cname), lhs.loc)
                          for cname in col_names]
             return col_names, data_arrs, [typ] * len(col_names)
 
@@ -786,12 +786,12 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
             out_types.append(typ)
             # output array variable
             data_arrs.append(
-                ir.Var(lhs.scope, numba.ir_utils.mk_unique_var(col_name), lhs.loc))
+                ir.Var(lhs.scope, numba.core.ir_utils.mk_unique_var(col_name), lhs.loc))
 
         return columns, data_arrs, out_types
 
     def _get_const_dtype(self, dtype_var):
-        dtype_def = guard(numba.ir_utils.get_definition, self.state.func_ir, dtype_var)
+        dtype_def = guard(numba.core.ir_utils.get_definition, self.state.func_ir, dtype_var)
         if isinstance(dtype_def, ir.Const) and isinstance(dtype_def.value, str):
             typ_name = dtype_def.value
             if typ_name == 'str':
@@ -819,7 +819,7 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
             return CategoricalArray(typ)
         if not isinstance(dtype_def, ir.Expr) or dtype_def.op != 'getattr':
             raise ValueError("pd.read_csv() invalid dtype")
-        glob_def = guard(numba.ir_utils.get_definition, self.state.func_ir, dtype_def.value)
+        glob_def = guard(numba.core.ir_utils.get_definition, self.state.func_ir, dtype_def.value)
         if not isinstance(glob_def, ir.Global) or glob_def.value != numpy:
             raise ValueError("pd.read_csv() invalid dtype")
         # TODO: extend to other types like string and date, check error
@@ -836,7 +836,7 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
         kws = dict(rhs.kws)
         objs_arg = self._get_arg('concat', rhs.args, kws, 0, 'objs')
 
-        df_list = guard(numba.ir_utils.get_definition, self.state.func_ir, objs_arg)
+        df_list = guard(numba.core.ir_utils.get_definition, self.state.func_ir, objs_arg)
         if not isinstance(df_list, ir.Expr) or not (df_list.op
                                                     in ['build_tuple', 'build_list']):
             raise ValueError("pd.concat input should be constant list or tuple")
@@ -886,17 +886,17 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
                 if cname not in df_col_map:
                     # use a df column just for len()
                     len_arr = list(df_col_map.values())[0]
-                    f_block = numba.ir_utils.compile_to_numba_ir(gen_nan_func,
+                    f_block = numba.core.ir_utils.compile_to_numba_ir(gen_nan_func,
                                                   {'sdc': sdc, 'numpy': numpy}).blocks.popitem()[1]
-                    numba.ir_utils.replace_arg_nodes(f_block, [len_arr])
+                    numba.core.ir_utils.replace_arg_nodes(f_block, [len_arr])
                     nodes += f_block.body[:-2]
                     args.append(nodes[-1].target)
                 else:
                     args.append(df_col_map[cname])
 
-            f_block = numba.ir_utils.compile_to_numba_ir(_concat_imp,
+            f_block = numba.core.ir_utils.compile_to_numba_ir(_concat_imp,
                                           {'sdc': sdc, 'numpy': numpy}).blocks.popitem()[1]
-            numba.ir_utils.replace_arg_nodes(f_block, args)
+            numba.core.ir_utils.replace_arg_nodes(f_block, args)
             nodes += f_block.body[:-2]
             done_cols[cname] = nodes[-1].target
 
@@ -921,16 +921,16 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
 
             def f(arr):
                 df_arr = sdc.hiframes.api.fix_df_array(arr)
-            f_block = numba.ir_utils.compile_to_numba_ir(
+            f_block = numba.core.ir_utils.compile_to_numba_ir(
                 f, {'sdc': sdc}).blocks.popitem()[1]
-            numba.ir_utils.replace_arg_nodes(f_block, [col_arr])
+            numba.core.ir_utils.replace_arg_nodes(f_block, [col_arr])
             nodes += f_block.body[:-3]  # remove none return
             new_col_arr = nodes[-1].target
             new_list.append((col_varname, new_col_arr))
         return nodes, new_list
 
     def _fix_df_list_of_array(self, col_arr):
-        list_call = guard(numba.ir_utils.get_definition, self.state.func_ir, col_arr)
+        list_call = guard(numba.core.ir_utils.get_definition, self.state.func_ir, col_arr)
         if guard(find_callname, self.state.func_ir, list_call) == ('list', 'builtins'):
             return list_call.args[0]
         return col_arr
@@ -951,9 +951,9 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
 
             def f(arr):
                 df_arr = sdc.hiframes.api.init_series(arr)
-            f_block = numba.ir_utils.compile_to_numba_ir(
+            f_block = numba.core.ir_utils.compile_to_numba_ir(
                 f, {'sdc': sdc}).blocks.popitem()[1]
-            numba.ir_utils.replace_arg_nodes(f_block, [item[1]])
+            numba.core.ir_utils.replace_arg_nodes(f_block, [item[1]])
             nodes += f_block.body[:-3]  # remove none return
             new_col_arr = nodes[-1].target
             df_cols[col_name] = new_col_arr
@@ -964,7 +964,7 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
         determines whether variable is coming from groupby() or groupby()[], rolling(), rolling()[]
         """
 
-        var_def = guard(numba.ir_utils.get_definition, self.state.func_ir, call_var)
+        var_def = guard(numba.core.ir_utils.get_definition, self.state.func_ir, call_var)
         # groupby()['B'] case
         if (isinstance(var_def, ir.Expr)
                 and var_def.op in ['getitem', 'static_getitem']):
@@ -980,9 +980,9 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
     def _get_str_arg(self, f_name, args, kws, arg_no, arg_name, default=None, err_msg=None):
         arg = None
         if len(args) > arg_no:
-            arg = guard(numba.ir_utils.find_const, self.state.func_ir, args[arg_no])
+            arg = guard(numba.core.ir_utils.find_const, self.state.func_ir, args[arg_no])
         elif arg_name in kws:
-            arg = guard(numba.ir_utils.find_const, self.state.func_ir, kws[arg_name])
+            arg = guard(numba.core.ir_utils.find_const, self.state.func_ir, kws[arg_name])
 
         if arg is None:
             if default is not None:
@@ -1041,10 +1041,10 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
             if as_index is False:
                 out_key_vars = []
                 for k in key_colnames:
-                    out_key_var = ir.Var(lhs.scope, numba.ir_utils.mk_unique_var(k), lhs.loc)
+                    out_key_var = ir.Var(lhs.scope, numba.core.ir_utils.mk_unique_var(k), lhs.loc)
                     out_df[k] = out_key_var
                     out_key_vars.append(out_key_var)
-            df_col_map = ({col: ir.Var(lhs.scope, numba.ir_utils.mk_unique_var(col), lhs.loc)
+            df_col_map = ({col: ir.Var(lhs.scope, numba.core.ir_utils.mk_unique_var(col), lhs.loc)
                            for col in out_colnames})
             out_df.update(df_col_map)
 
@@ -1063,7 +1063,7 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
         # sdc.jit() instead of numba.njit() to handle str arrs etc
         agg_func_dis = sdc.jit(agg_func)
         #agg_func_dis = numba.njit(agg_func)
-        agg_gb_var = ir.Var(lhs.scope, numba.ir_utils.mk_unique_var("agg_gb"), lhs.loc)
+        agg_gb_var = ir.Var(lhs.scope, numba.core.ir_utils.mk_unique_var("agg_gb"), lhs.loc)
         nodes = [ir.Assign(ir.Global("agg_gb", agg_func_dis, lhs.loc), agg_gb_var, lhs.loc)]
         for out_cname in out_colnames:
             in_var = in_vars[out_cname]
@@ -1071,20 +1071,20 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
             def to_arr(a, _agg_f):
                 b = sdc.hiframes.api.to_arr_from_series(a)
                 res = sdc.hiframes.api.init_series(sdc.hiframes.api.agg_typer(b, _agg_f))
-            f_block = numba.ir_utils.compile_to_numba_ir(to_arr, {'sdc': sdc, 'numpy': numpy}).blocks.popitem()[1]
-            numba.ir_utils.replace_arg_nodes(f_block, [in_var, agg_gb_var])
+            f_block = numba.core.ir_utils.compile_to_numba_ir(to_arr, {'sdc': sdc, 'numpy': numpy}).blocks.popitem()[1]
+            numba.core.ir_utils.replace_arg_nodes(f_block, [in_var, agg_gb_var])
             nodes += f_block.body[:-3]  # remove none return
             out_tp_vars[out_cname] = nodes[-1].target
         return nodes, agg_func, out_tp_vars
 
     def _get_agg_obj_args(self, agg_var):
         # find groupby key and as_index
-        groubpy_call = guard(numba.ir_utils.get_definition, self.state.func_ir, agg_var)
+        groubpy_call = guard(numba.core.ir_utils.get_definition, self.state.func_ir, agg_var)
         assert isinstance(groubpy_call, ir.Expr) and groubpy_call.op == 'call'
         kws = dict(groubpy_call.kws)
         as_index = True
         if 'as_index' in kws:
-            as_index = guard(numba.ir_utils.find_const, self.state.func_ir, kws['as_index'])
+            as_index = guard(numba.core.ir_utils.find_const, self.state.func_ir, kws['as_index'])
             if as_index is None:
                 raise ValueError("groupby as_index argument should be constant")
         if len(groubpy_call.args) == 1:
@@ -1105,30 +1105,30 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
 
         if by_arg_def is None:
             # try add_consts_to_type
-            by_arg_call = guard(numba.ir_utils.get_definition, self.state.func_ir, by_arg)
+            by_arg_call = guard(numba.core.ir_utils.get_definition, self.state.func_ir, by_arg)
             if guard(find_callname, self.state.func_ir, by_arg_call) == ('add_consts_to_type', 'sdc.hiframes.api'):
                 by_arg_def = guard(find_build_sequence, self.state.func_ir, by_arg_call.args[0])
 
         if by_arg_def is None:
             # try dict.keys()
-            by_arg_call = guard(numba.ir_utils.get_definition, self.state.func_ir, by_arg)
+            by_arg_call = guard(numba.core.ir_utils.get_definition, self.state.func_ir, by_arg)
             call_name = guard(find_callname, self.state.func_ir, by_arg_call)
             if (call_name is not None and len(call_name) == 2
                     and call_name[0] == 'keys'
                     and isinstance(call_name[1], ir.Var)):
-                var_def = guard(numba.ir_utils.get_definition, self.state.func_ir, call_name[1])
+                var_def = guard(numba.core.ir_utils.get_definition, self.state.func_ir, call_name[1])
                 if isinstance(var_def, ir.Expr) and var_def.op == 'build_map':
                     by_arg_def = [v[0] for v in var_def.items], 'build_map'
                     # HACK replace dict.keys getattr to avoid typing errors
                     keys_getattr = guard(
-                        numba.ir_utils.get_definition, self.state.func_ir, by_arg_call.func)
+                        numba.core.ir_utils.get_definition, self.state.func_ir, by_arg_call.func)
                     assert isinstance(
                         keys_getattr, ir.Expr) and keys_getattr.attr == 'keys'
                     keys_getattr.attr = 'copy'
 
         if by_arg_def is None:
             # try single key column
-            by_arg_def = guard(numba.ir_utils.find_const, self.state.func_ir, by_arg)
+            by_arg_def = guard(numba.core.ir_utils.find_const, self.state.func_ir, by_arg)
             if by_arg_def is None:
                 if default is not None:
                     return default
@@ -1139,7 +1139,7 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
                 if default is not None:
                     return default
                 raise ValueError(err_msg)
-            key_colnames = [guard(numba.ir_utils.find_const, self.state.func_ir, v) for v in by_arg_def[0]]
+            key_colnames = [guard(numba.core.ir_utils.find_const, self.state.func_ir, v) for v in by_arg_def[0]]
             if any(not isinstance(v, typ) for v in key_colnames):
                 if default is not None:
                     return default
@@ -1150,21 +1150,21 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
         """analyze selection of columns in after groupby() or rolling()
         e.g. groupby('A')['B'], groupby('A')['B', 'C'], groupby('A')
         """
-        select_def = guard(numba.ir_utils.get_definition, self.state.func_ir, obj_var)
+        select_def = guard(numba.core.ir_utils.get_definition, self.state.func_ir, obj_var)
         out_colnames = None
         explicit_select = False
         if isinstance(select_def, ir.Expr) and select_def.op in ('getitem', 'static_getitem'):
             obj_var = select_def.value
             out_colnames = (select_def.index
                             if select_def.op == 'static_getitem'
-                            else guard(numba.ir_utils.find_const, self.state.func_ir, select_def.index))
+                            else guard(numba.core.ir_utils.find_const, self.state.func_ir, select_def.index))
             if not isinstance(out_colnames, (str, tuple)):
                 raise ValueError("{} output column names should be constant".format(obj_name))
             if isinstance(out_colnames, str):
                 out_colnames = [out_colnames]
             explicit_select = True
 
-        obj_call = guard(numba.ir_utils.get_definition, self.state.func_ir, obj_var)
+        obj_call = guard(numba.core.ir_utils.get_definition, self.state.func_ir, obj_var)
         # find dataframe
         call_def = guard(find_callname, self.state.func_ir, obj_call)
         assert (call_def is not None and call_def[0] == obj_name
@@ -1183,15 +1183,15 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
         nodes = []
         # find selected output columns
         df_var, out_colnames, explicit_select, obj_var = self._get_df_obj_select(obj_var, 'rolling')
-        rolling_call = guard(numba.ir_utils.get_definition, self.state.func_ir, obj_var)
+        rolling_call = guard(numba.core.ir_utils.get_definition, self.state.func_ir, obj_var)
         window, center, on = get_rolling_setup_args(self.state.func_ir, rolling_call, False)
         on_arr = self.df_vars[df_var.name][on] if on is not None else None
         if not isinstance(center, ir.Var):
-            center_var = ir.Var(lhs.scope, numba.ir_utils.mk_unique_var("center"), lhs.loc)
+            center_var = ir.Var(lhs.scope, numba.core.ir_utils.mk_unique_var("center"), lhs.loc)
             nodes.append(ir.Assign(ir.Const(center, lhs.loc), center_var, lhs.loc))
             center = center_var
         if not isinstance(window, ir.Var):
-            window_var = ir.Var(lhs.scope, numba.ir_utils.mk_unique_var("window"), lhs.loc)
+            window_var = ir.Var(lhs.scope, numba.core.ir_utils.mk_unique_var("window"), lhs.loc)
             nodes.append(ir.Assign(ir.Const(window, lhs.loc), window_var, lhs.loc))
             window = window_var
         # TODO: get 'on' arg for offset case
@@ -1225,7 +1225,7 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
         if len(out_colnames) == 1 and explicit_select:
             df_col_map = {out_colnames[0]: lhs}
         else:
-            df_col_map = ({col: ir.Var(lhs.scope, numba.ir_utils.mk_unique_var(col), lhs.loc)
+            df_col_map = ({col: ir.Var(lhs.scope, numba.core.ir_utils.mk_unique_var(col), lhs.loc)
                            for col in out_colnames})
             if on is not None:
                 df_col_map[on] = on_arr
@@ -1246,8 +1246,8 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
         for cname in nan_cols:
             def f(arr):
                 nan_arr = numpy.full(len(arr), np.nan)
-            f_block = numba.ir_utils.compile_to_numba_ir(f, {'numpy': numpy}).blocks.popitem()[1]
-            numba.ir_utils.replace_arg_nodes(f_block, [len_arr])
+            f_block = numba.core.ir_utils.compile_to_numba_ir(f, {'numpy': numpy}).blocks.popitem()[1]
+            numba.core.ir_utils.replace_arg_nodes(f_block, [len_arr])
             nodes += f_block.body[:-3]  # remove none return
             out_df[cname] = nodes[-1].target
         if out_df is not None:
@@ -1298,8 +1298,8 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
                     df_arr = sdc.hiframes.api.init_series(sdc.hiframes.rolling.rolling_fixed(arr, w, center, False, _func_name))
                 args = [in_col_var, window, center]
 
-        f_block = numba.ir_utils.compile_to_numba_ir(f, {'sdc': sdc, '_func_name': func_name}).blocks.popitem()[1]
-        numba.ir_utils.replace_arg_nodes(f_block, args)
+        f_block = numba.core.ir_utils.compile_to_numba_ir(f, {'sdc': sdc, '_func_name': func_name}).blocks.popitem()[1]
+        numba.core.ir_utils.replace_arg_nodes(f_block, args)
         nodes += f_block.body[:-3]  # remove none return
         nodes[-1].target = out_col_var
 
@@ -1315,18 +1315,18 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
 
         df_var = inst.target
         # create var for string index
-        cname_var = ir.Var(inst.value.scope, numba.ir_utils.mk_unique_var("$cname_const"), inst.loc)
+        cname_var = ir.Var(inst.value.scope, numba.core.ir_utils.mk_unique_var("$cname_const"), inst.loc)
         nodes = [ir.Assign(ir.Const(inst.index, inst.loc), cname_var, inst.loc)]
 
         def func(df, cname, arr):
             return sdc.hiframes.api.set_df_col(df, cname, arr)
 
-        f_block = numba.ir_utils.compile_to_numba_ir(func, {'sdc': sdc}).blocks.popitem()[1]
-        numba.ir_utils.replace_arg_nodes(f_block, [df_var, cname_var, inst.value])
+        f_block = numba.core.ir_utils.compile_to_numba_ir(func, {'sdc': sdc}).blocks.popitem()[1]
+        numba.core.ir_utils.replace_arg_nodes(f_block, [df_var, cname_var, inst.value])
         nodes += f_block.body[:-2]
 
         # rename the dataframe variable to keep schema static
-        new_df_var = ir.Var(df_var.scope, numba.ir_utils.mk_unique_var(df_var.name), df_var.loc)
+        new_df_var = ir.Var(df_var.scope, numba.core.ir_utils.mk_unique_var(df_var.name), df_var.loc)
         nodes[-1].target = new_df_var
         self.replace_var_dict[df_var.name] = new_df_var
 
@@ -1382,8 +1382,8 @@ class SDC_Pandas_DataFrame_TransformationPass_Stage1(FunctionPass):
         return
 
 def _gen_arr_copy(in_arr, nodes):
-    f_block = numba.ir_utils.compile_to_numba_ir(lambda A: A.copy(), {}).blocks.popitem()[1]
-    numba.ir_utils.replace_arg_nodes(f_block, [in_arr])
+    f_block = numba.core.ir_utils.compile_to_numba_ir(lambda A: A.copy(), {}).blocks.popitem()[1]
+    numba.core.ir_utils.replace_arg_nodes(f_block, [in_arr])
     nodes += f_block.body[:-2]
     return nodes[-1].target
 

--- a/sdc/datatypes/hpat_pandas_dataframe_rolling_functions.py
+++ b/sdc/datatypes/hpat_pandas_dataframe_rolling_functions.py
@@ -26,7 +26,7 @@
 import numpy
 import pandas
 
-from numba.types import (float64, Boolean, Integer, Number, Omitted,
+from numba.core.types import (float64, Boolean, Integer, Number, Omitted,
                          NoneType, StringLiteral, UnicodeType)
 from sdc.utilities.sdc_typing_utils import TypeChecker, kwsparams2list
 from sdc.datatypes.hpat_pandas_dataframe_rolling_types import DataFrameRollingType

--- a/sdc/datatypes/hpat_pandas_dataframe_types.py
+++ b/sdc/datatypes/hpat_pandas_dataframe_types.py
@@ -35,10 +35,11 @@
 import operator
 import pandas
 
-from numba import types, cgutils
+from numba import types
+from numba.core import cgutils
 from numba.extending import (models, overload, register_model, make_attribute_wrapper, intrinsic, box, unbox)
-from numba.datamodel import register_default, StructModel
-from numba.typing.templates import signature, infer_global, AbstractTemplate
+from numba.core.datamodel import register_default, StructModel
+from numba.core.typing.templates import signature, infer_global, AbstractTemplate
 
 from sdc.config import config_pipeline_hpat_default
 

--- a/sdc/datatypes/hpat_pandas_functions.py
+++ b/sdc/datatypes/hpat_pandas_functions.py
@@ -32,8 +32,9 @@ import pandas as pd
 import numpy as np
 
 import numba
-from numba import types, numpy_support
-from numba.errors import TypingError
+from numba import types
+from numba.np import numpy_support
+from numba.core.errors import TypingError
 from numba.extending import overload
 
 from sdc.io.csv_ext import (

--- a/sdc/datatypes/hpat_pandas_getitem_types.py
+++ b/sdc/datatypes/hpat_pandas_getitem_types.py
@@ -27,10 +27,11 @@
 
 import pandas
 
-from numba import types, cgutils
+from numba import types
+from numba.core import cgutils
 from numba.extending import (models, overload, register_model, make_attribute_wrapper, intrinsic)
-from numba.datamodel import (register_default, StructModel)
-from numba.typing.templates import signature
+from numba.core.datamodel import (register_default, StructModel)
+from numba.core.typing.templates import signature
 
 
 class SeriesGetitemAccessorType(types.Type):

--- a/sdc/datatypes/hpat_pandas_groupby_functions.py
+++ b/sdc/datatypes/hpat_pandas_groupby_functions.py
@@ -35,12 +35,12 @@ import operator
 import sdc
 
 from numba import types
-from numba import cgutils
+from numba.core import cgutils
 from numba.extending import intrinsic
-from numba.targets.registry import cpu_target
+from numba.core.registry import cpu_target
 from numba.typed import List, Dict
-from numba.typing import signature
-from numba.special import literally
+from numba.core.typing import signature
+from numba import literally
 
 from sdc.datatypes.common_functions import sdc_arrays_argsort, _sdc_asarray, _sdc_take
 from sdc.datatypes.hpat_pandas_groupby_types import DataFrameGroupByType, SeriesGroupByType
@@ -98,7 +98,7 @@ def init_dataframe_groupby(typingctx, parent, column_id, data, sort, target_colu
         groupby_obj.sort = sort_val
         groupby_obj.target_default = context.get_constant(types.bool_, target_not_specified)
 
-        column_strs = [numba.unicode.make_string_from_constant(
+        column_strs = [numba.cpython.unicode.make_string_from_constant(
             context, builder, string_type, c) for c in selected_col_names]
         column_tup = context.make_tuple(
             builder, types.UniTuple(string_type, n_target_cols), column_strs)

--- a/sdc/datatypes/hpat_pandas_rolling_types.py
+++ b/sdc/datatypes/hpat_pandas_rolling_types.py
@@ -24,10 +24,10 @@
 # EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # *****************************************************************************
 
-from numba import cgutils, types
-from numba.datamodel import StructModel
+from numba.core import cgutils, types
+from numba.core.datamodel import StructModel
 from numba.extending import make_attribute_wrapper, models
-from numba.typing.templates import signature
+from numba.core.typing.templates import signature
 from sdc.utilities.sdc_typing_utils import TypeChecker
 
 

--- a/sdc/datatypes/hpat_pandas_series_functions.py
+++ b/sdc/datatypes/hpat_pandas_series_functions.py
@@ -36,13 +36,15 @@ import pandas
 import math
 import sys
 
-from numba.errors import TypingError
-from numba.typing import signature
+from numba.core.errors import TypingError
+from numba.core.typing import signature
 from numba.extending import intrinsic
-from numba import (types, numpy_support, cgutils)
+from numba import types
+from numba.core import cgutils
+from numba.np import numpy_support
 from numba.typed import List, Dict
 from numba import prange
-from numba.targets.arraymath import get_isnan
+from numba.np.arraymath import get_isnan
 from pandas.core.indexing import IndexingError
 
 import sdc

--- a/sdc/datatypes/hpat_pandas_series_rolling_functions.py
+++ b/sdc/datatypes/hpat_pandas_series_rolling_functions.py
@@ -31,7 +31,7 @@ from functools import partial
 
 from numba import prange
 from numba.extending import register_jitable
-from numba.types import (float64, Boolean, Integer, NoneType, Number,
+from numba.core.types import (float64, Boolean, Integer, NoneType, Number,
                          Omitted, StringLiteral, UnicodeType)
 
 from sdc.datatypes.common_functions import _almost_equal

--- a/sdc/datatypes/hpat_pandas_stringmethods_functions.py
+++ b/sdc/datatypes/hpat_pandas_stringmethods_functions.py
@@ -45,7 +45,7 @@
         ty_checker.check(self, StringMethodsType)
 
         def hpat_pandas_stringmethods_upper_parallel_impl(self):
-            from numba.parfor import (init_prange, min_checker, internal_prange)
+            from numba.parfors.parfor import (init_prange, min_checker, internal_prange)
 
             init_prange()
             result = []
@@ -81,7 +81,7 @@ import numpy
 import pandas
 
 import numba
-from numba.types import (Boolean, Integer, NoneType,
+from numba.core.types import (Boolean, Integer, NoneType,
                          Omitted, StringLiteral, UnicodeType)
 
 from sdc.utilities.sdc_typing_utils import TypeChecker

--- a/sdc/datatypes/hpat_pandas_stringmethods_types.py
+++ b/sdc/datatypes/hpat_pandas_stringmethods_types.py
@@ -32,10 +32,11 @@
 
 import pandas
 
-from numba import types, cgutils
+from numba import types
+from numba.core import cgutils
 from numba.extending import (models, overload, register_model, make_attribute_wrapper, intrinsic)
-from numba.datamodel import (register_default, StructModel)
-from numba.typing.templates import signature
+from numba.core.datamodel import (register_default, StructModel)
+from numba.core.typing.templates import signature
 from sdc.hiframes.split_impl import SplitViewStringMethodsType, StringArraySplitViewType
 from sdc.utilities.utils import sdc_overload
 

--- a/sdc/datatypes/pandas_series_functions/apply.py
+++ b/sdc/datatypes/pandas_series_functions/apply.py
@@ -27,7 +27,7 @@
 import numpy
 import pandas
 from numba import prange, types
-from numba.targets.registry import cpu_target
+from numba.core.registry import cpu_target
 
 from sdc.hiframes.pd_series_ext import SeriesType
 from sdc.utilities.utils import sdc_overload_method

--- a/sdc/datatypes/pandas_series_functions/map.py
+++ b/sdc/datatypes/pandas_series_functions/map.py
@@ -27,7 +27,7 @@
 import numpy
 import pandas
 from numba import prange, types
-from numba.targets.registry import cpu_target
+from numba.core.registry import cpu_target
 
 from sdc.hiframes.pd_series_ext import SeriesType
 from sdc.utilities.utils import sdc_overload_method

--- a/sdc/distributed.py
+++ b/sdc/distributed.py
@@ -40,8 +40,10 @@ from collections import defaultdict
 import numpy as np
 
 import numba
-from numba import ir, ir_utils, postproc, types
-from numba.ir_utils import (
+from numba import types
+from numba.core import ir, ir_utils
+from numba.core import postproc
+from numba.core.ir_utils import (
     mk_unique_var,
     replace_vars_inner,
     find_topo_order,
@@ -64,8 +66,8 @@ from numba.ir_utils import (
     find_build_sequence,
     find_const,
     is_get_setitem)
-from numba.inline_closurecall import inline_closure_call
-from numba.parfor import (
+from numba.core.inline_closurecall import inline_closure_call
+from numba.parfors.parfor import (
     Parfor,
     lower_parfor_sequential,
     get_parfor_reductions,
@@ -73,7 +75,7 @@ from numba.parfor import (
     wrap_parfor_blocks,
     unwrap_parfor_blocks)
 
-from numba.compiler_machinery import FunctionPass, register_pass
+from numba.core.compiler_machinery import FunctionPass, register_pass
 
 import sdc
 import sdc.utilities.utils
@@ -983,7 +985,7 @@ class DistributedPassImpl(object):
             arg_typs = tuple(arg_typs)
             # self.state.calltypes[rhs] = self.state.typemap[rhs.func.name].get_call_type(
             #      self.state.typingctx, arg_typs, {})
-            self.state.calltypes[rhs] = numba.typing.Signature(
+            self.state.calltypes[rhs] = numba.core.typing.Signature(
                 string_type, arg_typs, new_df_typ,
                 call_type.pysig)
 
@@ -1960,11 +1962,11 @@ class DistributedPassImpl(object):
         if rhs.op == 'call':
             func = find_callname(self.state.func_ir, rhs, self.state.typemap)
             if func == ('min', 'builtins'):
-                if isinstance(self.state.typemap[rhs.args[0].name], numba.typing.builtins.IndexValueType):
+                if isinstance(self.state.typemap[rhs.args[0].name], numba.core.typing.builtins.IndexValueType):
                     return Reduce_Type.Argmin
                 return Reduce_Type.Min
             if func == ('max', 'builtins'):
-                if isinstance(self.state.typemap[rhs.args[0].name], numba.typing.builtins.IndexValueType):
+                if isinstance(self.state.typemap[rhs.args[0].name], numba.core.typing.builtins.IndexValueType):
                     return Reduce_Type.Argmax
                 return Reduce_Type.Max
 

--- a/sdc/distributed_analysis.py
+++ b/sdc/distributed_analysis.py
@@ -31,13 +31,15 @@ import copy
 import warnings
 
 import numba
-from numba import ir, ir_utils, types
-from numba.ir_utils import (find_topo_order, guard, get_definition, require,
+from numba import types
+from numba.core import ir, ir_utils
+from numba.core.ir_utils import (find_topo_order, guard, get_definition, require,
                             find_callname, mk_unique_var, compile_to_numba_ir,
                             replace_arg_nodes, build_definitions,
                             find_build_sequence, find_const)
-from numba.parfor import Parfor
-from numba.parfor import wrap_parfor_blocks, unwrap_parfor_blocks
+from numba.parfors.parfor import Parfor
+from numba.parfors.parfor import wrap_parfor_blocks, unwrap_parfor_blocks
+from numba.core import analysis
 
 import sdc
 import sdc.io
@@ -489,7 +491,7 @@ class DistributedAnalysis(object):
 
         # TODO: make sure assert_equiv is not generated unnecessarily
         # TODO: fix assert_equiv for np.stack from df.value
-        if fdef == ('assert_equiv', 'numba.array_analysis'):
+        if fdef == ('assert_equiv', 'numba.parfors.parfor.array_analysis'):
             return
 
         # we perform call-analysis from external at the end
@@ -873,7 +875,7 @@ class DistributedAnalysis(object):
         # arrays or is in a loop
 
         # find sequential loop bodies
-        cfg = numba.analysis.compute_cfg_from_blocks(self.func_ir.blocks)
+        cfg = analysis.compute_cfg_from_blocks(self.func_ir.blocks)
         loop_bodies = set()
         for loop in cfg.loops().values():
             loop_bodies |= loop.body

--- a/sdc/distributed_api.py
+++ b/sdc/distributed_api.py
@@ -39,8 +39,8 @@ import numpy as np
 import numba
 from numba import types
 from numba.extending import models, overload, register_model
-from numba.typing import signature
-from numba.typing.templates import AbstractTemplate, infer_global
+from numba.core.typing import signature
+from numba.core.typing.templates import AbstractTemplate, infer_global
 
 import sdc
 from sdc.str_arr_ext import (string_array_type, num_total_chars, StringArray,

--- a/sdc/distributed_lower.py
+++ b/sdc/distributed_lower.py
@@ -33,14 +33,15 @@ import numpy as np
 from llvmlite import ir as lir
 import llvmlite.binding as ll
 
-import numba.targets.arrayobj
-from numba import types, cgutils
+import numba.np.arrayobj
+from numba import types
+from numba.core import cgutils
 from numba.extending import overload
-from numba.targets.imputils import impl_ret_borrowed, lower_builtin
-from numba.targets.arrayobj import make_array
-from numba.typing import signature
-from numba.typing.templates import infer_global, AbstractTemplate
-from numba.typing.builtins import IndexValueType
+from numba.core.imputils import impl_ret_borrowed, lower_builtin
+from numba.np.arrayobj import make_array
+from numba.core.typing import signature
+from numba.core.typing.templates import infer_global, AbstractTemplate
+from numba.core.typing.builtins import IndexValueType
 
 import sdc
 from sdc import distributed_api
@@ -488,7 +489,7 @@ def setitem_req_array(context, builder, sig, args):
 #
 #     # replace inner array access call for setitem generation
 #     cgutils.get_item_pointer2 = dist_get_item_pointer2
-#     numba.targets.arrayobj.setitem_array(context, builder, sig, args)
+#     numba.np.arrayobj.setitem_array(context, builder, sig, args)
 #     cgutils.get_item_pointer2 = regular_get_item_pointer2
 #     return lir.Constant(lir.IntType(32), 0)
 

--- a/sdc/functions/numpy_like.py
+++ b/sdc/functions/numpy_like.py
@@ -38,9 +38,10 @@ import sys
 import pandas
 import numpy as np
 
-from numba import types, jit, prange, numpy_support, literally
-from numba.errors import TypingError
-from numba.targets.arraymath import get_isnan
+from numba import types, jit, prange, literally
+from numba.np import numpy_support
+from numba.core.errors import TypingError
+from numba.np.arraymath import get_isnan
 
 import sdc
 from sdc.utilities.sdc_typing_utils import TypeChecker
@@ -645,7 +646,7 @@ def nanprod(a):
 @sdc_overload(nanprod)
 def np_nanprod(a):
     """
-    Reimplemented with parfor from numba.targets.arraymath.
+    Reimplemented with parfor from numba.np.arraymath.
     """
     if not isinstance(a, types.Array):
         return

--- a/sdc/hiframes/boxing.py
+++ b/sdc/hiframes/boxing.py
@@ -33,11 +33,13 @@ import datetime
 import numba
 from numba.extending import (typeof_impl, unbox, register_model, models,
                              NativeValue, box, intrinsic)
-from numba import numpy_support, types, cgutils
-from numba.typing import signature
-from numba.targets.boxing import box_array, unbox_array, box_list
-from numba.targets.boxing import _NumbaTypeHelper
-from numba.targets import listobj
+from numba import types
+from numba.core import cgutils
+from numba.np import numpy_support
+from numba.core.typing import signature
+from numba.core.boxing import box_array, unbox_array, box_list
+from numba.core.boxing import _NumbaTypeHelper
+from numba.cpython import listobj
 
 from sdc.hiframes.pd_dataframe_type import DataFrameType
 from sdc.hiframes.pd_timestamp_ext import (datetime_date_type,
@@ -93,7 +95,7 @@ def unbox_dataframe(typ, val, c):
     columns will be extracted later if necessary.
     """
     n_cols = len(typ.columns)
-    column_strs = [numba.unicode.make_string_from_constant(
+    column_strs = [numba.cpython.unicode.make_string_from_constant(
         c.context, c.builder, string_type, a) for a in typ.columns]
     # create dataframe struct and store values
     dataframe = cgutils.create_struct_proxy(typ)(c.context, c.builder)
@@ -322,7 +324,7 @@ def unbox_series(typ, val, c):
 
     if typ.is_named:
         name_obj = c.pyapi.object_getattr_string(val, "name")
-        series.name = numba.unicode.unbox_unicode_str(
+        series.name = numba.cpython.unicode.unbox_unicode_str(
             string_type, name_obj, c).value
     # TODO: handle index and name
     c.pyapi.decref(arr_obj)
@@ -385,7 +387,7 @@ def _box_series_data(dtype, data_typ, val, c):
     if isinstance(dtype, types.BaseTuple):
         np_dtype = np.dtype(
             ','.join(str(t) for t in dtype.types), align=True)
-        dtype = numba.numpy_support.from_dtype(np_dtype)
+        dtype = numba.np.numpy_support.from_dtype(np_dtype)
 
     if dtype == string_type:
         arr = box_str_arr(string_array_type, val, c)

--- a/sdc/hiframes/dataframe_pass.py
+++ b/sdc/hiframes/dataframe_pass.py
@@ -33,14 +33,14 @@ import warnings
 
 import numba
 from numba import ir, ir_utils, types
-from numba.ir_utils import (replace_arg_nodes, compile_to_numba_ir,
+from numba.core.ir_utils import (replace_arg_nodes, compile_to_numba_ir,
                             find_topo_order, gen_np_call, get_definition, guard,
                             find_callname, mk_alloc, find_const, is_setitem,
                             is_getitem, mk_unique_var, dprint_func_ir,
                             build_definitions, find_build_sequence,
                             GuardException, compute_cfg_from_blocks)
-from numba.inline_closurecall import inline_closure_call
-from numba.compiler_machinery import FunctionPass, register_pass
+from numba.core.inline_closurecall import inline_closure_call
+from numba.core.compiler_machinery import FunctionPass, register_pass
 import sdc
 from sdc import hiframes
 from sdc.utilities.utils import (debug_prints, inline_new_blocks, ReplaceFunc,
@@ -1048,10 +1048,10 @@ class DataFramePassImpl(object):
         # make series to enable getitem of dt64 to timestamp for example
         for i in range(len(used_cols)):
             func_text += "  c{} = sdc.hiframes.api.init_series(c{})\n".format(i, i)
-        func_text += "  numba.parfor.init_prange()\n"
+        func_text += "  numba.parfors.parfor.init_prange()\n"
         func_text += "  n = len(c0)\n"
         func_text += "  S = numba.unsafe.ndarray.empty_inferred((n,))\n"
-        func_text += "  for i in numba.parfor.internal_prange(n):\n"
+        func_text += "  for i in numba.parfors.parfor.internal_prange(n):\n"
         func_text += "     row = Row({})\n".format(row_args)
         func_text += "     S[i] = map_func(row)\n"
         func_text += "  return sdc.hiframes.api.init_series(S)\n"
@@ -1795,9 +1795,9 @@ class DataFramePassImpl(object):
         pivot_arr = columns
 
         def _agg_len_impl(in_arr):  # pragma: no cover
-            numba.parfor.init_prange()
+            numba.parfors.parfor.init_prange()
             count = 0
-            for i in numba.parfor.internal_prange(len(in_arr)):
+            for i in numba.parfors.parfor.internal_prange(len(in_arr)):
                 count += 1
             return count
 
@@ -2204,7 +2204,7 @@ class DataFramePassImpl(object):
                 return d_var
 
             # TODO: stararg needs special handling?
-            args = numba.typing.fold_arguments(
+            args = numba.core.typing.fold_arguments(
                 pysig, args, kws, normal_handler, default_handler,
                 normal_handler)
 

--- a/sdc/hiframes/datetime_date_ext.py
+++ b/sdc/hiframes/datetime_date_ext.py
@@ -28,10 +28,10 @@
 from numba import types
 from numba.extending import (typeof_impl, unbox, register_model, models,
                              NativeValue, box)
-from numba.typing.templates import infer_global, AbstractTemplate
-from numba.targets.imputils import (impl_ret_new_ref, impl_ret_borrowed,
+from numba.core.typing.templates import infer_global, AbstractTemplate
+from numba.core.imputils import (impl_ret_new_ref, impl_ret_borrowed,
                                     lower_builtin)
-from numba.typing import signature
+from numba.core.typing import signature
 
 from sdc.hiframes.pd_timestamp_ext import (datetime_date_type,
                                             box_datetime_date_array)

--- a/sdc/hiframes/hiframes_untyped.py
+++ b/sdc/hiframes/hiframes_untyped.py
@@ -31,11 +31,12 @@ from collections import namedtuple
 import itertools
 
 import numba
-from numba import ir, ir_utils, types
-from numba import compiler as numba_compiler
-from numba.targets.registry import CPUDispatcher
+from numba import types
+from numba.core import ir, ir_utils
+from numba.core import compiler as numba_compiler
+from numba.core.registry import CPUDispatcher
 
-from numba.ir_utils import (mk_unique_var, replace_vars_inner, find_topo_order,
+from numba.core.ir_utils import (mk_unique_var, replace_vars_inner, find_topo_order,
                             dprint_func_ir, remove_dead, mk_alloc, remove_dels,
                             get_name_var_table, replace_var_names,
                             add_offset_to_labels, get_ir_of_code, find_const,
@@ -44,9 +45,9 @@ from numba.ir_utils import (mk_unique_var, replace_vars_inner, find_topo_order,
                             build_definitions, replace_vars_stmt,
                             replace_vars_inner, find_build_sequence)
 
-from numba.inline_closurecall import inline_closure_call
-from numba.analysis import compute_cfg_from_blocks
-from numba.compiler_machinery import FunctionPass, register_pass
+from numba.core.inline_closurecall import inline_closure_call
+from numba.core.analysis import compute_cfg_from_blocks
+from numba.core.compiler_machinery import FunctionPass, register_pass
 
 import sdc
 from sdc import config
@@ -82,7 +83,7 @@ def remove_hiframes(rhs, lives, call_list):
         return True
     # used in stencil generation of rolling
     if (len(call_list) == 1 and isinstance(call_list[0], CPUDispatcher)
-            and call_list[0].py_func == numba.stencilparfor._compute_last_ind):
+            and call_list[0].py_func == numba.stencils.stencilparfor._compute_last_ind):
         return True
     # used in stencil generation of rolling
     if call_list == ['ceil', math]:
@@ -128,7 +129,7 @@ def remove_hiframes(rhs, lives, call_list):
     return False
 
 
-numba.ir_utils.remove_call_handlers.append(remove_hiframes)
+numba.core.ir_utils.remove_call_handlers.append(remove_hiframes)
 
 
 @register_pass(mutates_CFG=True, analysis_only=False)

--- a/sdc/hiframes/pd_categorical_ext.py
+++ b/sdc/hiframes/pd_categorical_ext.py
@@ -29,9 +29,9 @@ import numba
 from numba.extending import (box, unbox, typeof_impl, register_model, models,
                              NativeValue, lower_builtin, lower_cast, overload,
                              type_callable, overload_method, intrinsic)
-from numba.targets.imputils import impl_ret_borrowed
+from numba.core.imputils import impl_ret_borrowed
 from numba import types
-from numba.targets.boxing import box_array, unbox_array
+from numba.core.boxing import box_array, unbox_array
 
 import numpy as np
 import pandas as pd

--- a/sdc/hiframes/pd_dataframe_ext.py
+++ b/sdc/hiframes/pd_dataframe_ext.py
@@ -31,13 +31,14 @@ import pandas as pd
 import numpy as np
 
 import numba
-from numba import types, cgutils
+from numba import types
+from numba.core import cgutils
 from numba.extending import (models, register_model, lower_cast, infer_getattr,
                              type_callable, infer, overload, intrinsic,
                              lower_builtin, overload_method)
-from numba.typing.templates import (infer_global, AbstractTemplate, signature,
+from numba.core.typing.templates import (infer_global, AbstractTemplate, signature,
                                     AttributeTemplate, bound_function)
-from numba.targets.imputils import impl_ret_new_ref, impl_ret_borrowed
+from numba.core.imputils import impl_ret_new_ref, impl_ret_borrowed
 
 import sdc
 from sdc.hiframes.pd_series_ext import SeriesType
@@ -116,7 +117,7 @@ def init_dataframe(typingctx, *args):
         in_tup = args[0]
         data_arrs = [builder.extract_value(in_tup, i) for i in range(n_cols)]
         index = builder.extract_value(in_tup, n_cols)
-        column_strs = [numba.unicode.make_string_from_constant(
+        column_strs = [numba.cpython.unicode.make_string_from_constant(
             context, builder, string_type, c) for c in column_names]
         # create dataframe struct and store values
         dataframe = cgutils.create_struct_proxy(
@@ -243,7 +244,7 @@ def set_df_column_with_reflect(typingctx, df, cname, arr):
         if is_new_col:
             data_arrs.append(arr_arg)
 
-        column_strs = [numba.unicode.make_string_from_constant(
+        column_strs = [numba.cpython.unicode.make_string_from_constant(
             context, builder, string_type, c) for c in column_names]
 
         zero = context.get_constant(types.int8, 0)
@@ -1372,7 +1373,7 @@ class SumDummyTyper(AbstractTemplate):
         df = args[0]
         # TODO: ignore non-numerics
         # get series sum output types
-        dtypes = tuple(numba.typing.arraydecl.ArrayAttribute.resolve_sum(
+        dtypes = tuple(numba.core.typing.arraydecl.ArrayAttribute.resolve_sum(
             self, SeriesType(d.dtype)).get_call_type(self, (), {}).return_type
             for d in df.data)
 
@@ -1412,7 +1413,7 @@ class ProdDummyTyper(AbstractTemplate):
         df = args[0]
         # TODO: ignore non-numerics
         # get series prod output types
-        dtypes = tuple(numba.typing.arraydecl.ArrayAttribute.resolve_prod(
+        dtypes = tuple(numba.core.typing.arraydecl.ArrayAttribute.resolve_prod(
             self, SeriesType(d.dtype)).get_call_type(self, (), {}).return_type
             for d in df.data)
 

--- a/sdc/hiframes/pd_dataframe_type.py
+++ b/sdc/hiframes/pd_dataframe_type.py
@@ -26,7 +26,8 @@
 
 
 import numba
-from numba import types, cgutils
+from numba import types
+from numba.core import cgutils
 from numba.extending import (models, register_model, make_attribute_wrapper)
 
 from sdc.str_ext import string_type

--- a/sdc/hiframes/pd_index_ext.py
+++ b/sdc/hiframes/pd_index_ext.py
@@ -30,9 +30,9 @@ import numba
 from numba import types
 from numba.extending import (models, register_model, lower_cast, infer_getattr,
                              type_callable, infer, overload, make_attribute_wrapper, box)
-from numba.typing.templates import (infer_global, AbstractTemplate, signature,
+from numba.core.typing.templates import (infer_global, AbstractTemplate, signature,
                                     AttributeTemplate, bound_function)
-from numba.targets.boxing import box_array
+from numba.core.boxing import box_array
 
 import sdc
 from sdc.str_ext import string_type
@@ -99,7 +99,7 @@ def box_dt_index(typ, val, c):
     mod_name = c.context.insert_const_string(c.builder.module, "pandas")
     pd_class_obj = c.pyapi.import_module_noblock(mod_name)
 
-    dt_index = numba.cgutils.create_struct_proxy(
+    dt_index = numba.core.cgutils.create_struct_proxy(
         typ)(c.context, c.builder, val)
 
     arr = box_array(_dt_index_data_typ, dt_index.data, c)

--- a/sdc/hiframes/pd_series_ext.py
+++ b/sdc/hiframes/pd_series_ext.py
@@ -27,7 +27,8 @@
 import pandas as pd
 
 import numba
-from numba import types, cgutils
+from numba import types
+from numba.core import cgutils
 from numba.extending import (
     models,
     register_model,

--- a/sdc/hiframes/pd_series_type.py
+++ b/sdc/hiframes/pd_series_type.py
@@ -28,11 +28,12 @@ import llvmlite.llvmpy.core as lc
 
 import numpy as np
 
-from numba import types, cgutils
-from numba.numpy_support import from_dtype
+from numba import types
+from numba.core import cgutils
+from numba.np.numpy_support import from_dtype
 from numba.extending import (models, register_model, make_attribute_wrapper, lower_builtin)
-from numba.targets.imputils import (impl_ret_new_ref, iternext_impl, RefType)
-from numba.targets.arrayobj import (make_array, _getitem_array1d)
+from numba.core.imputils import (impl_ret_new_ref, iternext_impl, RefType)
+from numba.np.arrayobj import (make_array, _getitem_array1d)
 
 from sdc.str_arr_ext import string_array_type
 from sdc.str_ext import string_type, list_string_array_type
@@ -207,7 +208,7 @@ def getiter_series(context, builder, sig, args):
     return out
 
 
-# TODO: call it from numba.targets.arrayobj, need separate function in numba
+# TODO: call it from numba.np.arrayobj, need separate function in numba
 def iternext_series_array(context, builder, sig, args, result):
     """
     Implementation of iternext() for the ArrayIterator type

--- a/sdc/hiframes/pd_timestamp_ext.py
+++ b/sdc/hiframes/pd_timestamp_ext.py
@@ -31,10 +31,10 @@ from numba import types
 from numba.extending import (typeof_impl, type_callable, models, register_model, NativeValue,
                              make_attribute_wrapper, lower_builtin, box, unbox, lower_cast,
                              lower_getattr, infer_getattr, overload_method, overload, intrinsic)
-from numba import cgutils
-from numba.targets.arrayobj import make_array, _empty_nd_impl, store_item, basic_indexing
-from numba.targets.boxing import box_array
-from numba.typing.templates import (infer_getattr, AttributeTemplate,
+from numba.core import cgutils
+from numba.np.arrayobj import make_array, _empty_nd_impl, store_item, basic_indexing
+from numba.core.boxing import box_array
+from numba.core.typing.templates import (infer_getattr, AttributeTemplate,
                                     bound_function, signature, infer_global, AbstractTemplate,
                                     ConcreteTemplate)
 
@@ -166,7 +166,7 @@ class CmpOpNe(CompDT64):
     key = operator.ne
 
 
-class MinMaxBaseDT64(numba.typing.builtins.MinMaxBase):
+class MinMaxBaseDT64(numba.core.typing.builtins.MinMaxBase):
 
     def _unify_minmax(self, tys):
         for ty in tys:
@@ -992,7 +992,7 @@ def parse_datetime_str(str):
 #             else:
 #                 assert isinstance(idx, types.Integer)
 #                 return signature(pandas_timestamp_type, *args)
-# from numba.targets.listobj import ListInstance
+# from numba.cpython.listobj import ListInstance
 # from llvmlite import ir as lir
 # import llvmlite.binding as ll
 # #from .. import hdatetime_ext

--- a/sdc/hiframes/rolling.py
+++ b/sdc/hiframes/rolling.py
@@ -28,7 +28,7 @@
 import pandas as pd
 import sdc
 import numba
-from numba.ir_utils import guard, find_const
+from numba.core.ir_utils import guard, find_const
 
 
 supported_rolling_funcs = ('sum', 'mean', 'var', 'std', 'count', 'median',

--- a/sdc/hiframes/split_impl.py
+++ b/sdc/hiframes/split_impl.py
@@ -31,17 +31,17 @@ import pandas
 import numba
 import sdc
 from numba import types
-from numba.typing.templates import (infer_global, AbstractTemplate, infer,
+from numba.core.typing.templates import (infer_global, AbstractTemplate, infer,
                                     signature, AttributeTemplate, infer_getattr, bound_function)
-import numba.typing.typeof
-from numba.datamodel import StructModel
-from numba.errors import TypingError
+import numba.core.typing.typeof
+from numba.core.datamodel import StructModel
+from numba.core.errors import TypingError
 from numba.extending import (typeof_impl, type_callable, models, register_model, NativeValue,
                              make_attribute_wrapper, lower_builtin, box, unbox,
                              lower_getattr, intrinsic, overload_method, overload, overload_attribute)
-from numba import cgutils
+from numba.core import cgutils
 from sdc.str_ext import string_type
-from numba.targets.imputils import (impl_ret_new_ref, impl_ret_borrowed,
+from numba.core.imputils import (impl_ret_new_ref, impl_ret_borrowed,
                                     iternext_impl, RefType)
 from sdc.str_arr_ext import (string_array_type, get_data_ptr,
                               is_str_arr_typ, pre_alloc_string_array, _memcpy)
@@ -486,7 +486,7 @@ def hpat_pandas_spliview_stringmethods_len(self):
 @overload(operator.getitem)
 def str_arr_split_view_getitem_overload(A, ind):
     if A == string_array_split_view_type and isinstance(ind, types.Integer):
-        kind = numba.unicode.PY_UNICODE_1BYTE_KIND
+        kind = numba.cpython.unicode.PY_UNICODE_1BYTE_KIND
 
         def _impl(A, ind):
             start_index = getitem_c_arr(A._index_offsets, ind)
@@ -504,7 +504,7 @@ def str_arr_split_view_getitem_overload(A, ind):
                 data_end = getitem_c_arr(
                     A._data_offsets, start_index + i + 1)
                 length = data_end - data_start
-                _str = numba.unicode._empty_string(kind, length)
+                _str = numba.cpython.unicode._empty_string(kind, length)
                 ptr = get_array_ctypes_ptr(A._data, data_start)
                 _memcpy(_str._data, ptr, length, 1)
                 str_list[i] = _str

--- a/sdc/io/csv_ext.py
+++ b/sdc/io/csv_ext.py
@@ -33,11 +33,13 @@ from llvmlite import ir as lir
 from .. import hio
 from collections import defaultdict
 import numba
-from numba import typeinfer, ir, ir_utils, config, types, cgutils
-from numba.typing.templates import signature
+from numba.core import typeinfer, ir, ir_utils, types
+from numba.core.typing.templates import signature
 from numba.extending import overload, intrinsic, register_model, models, box
-from numba.ir_utils import (visit_vars_inner, replace_vars_inner,
+from numba.core.ir_utils import (visit_vars_inner, replace_vars_inner,
                             compile_to_numba_ir, replace_arg_nodes)
+from numba.core import analysis
+from numba.parfors import array_analysis
 import sdc
 from sdc import distributed, distributed_analysis
 from sdc.utilities.utils import (debug_prints, alloc_arr_tup, empty_like_type,
@@ -104,7 +106,7 @@ def csv_array_analysis(csv_node, equiv_set, typemap, array_analysis):
     return [], post
 
 
-numba.array_analysis.array_analysis_extensions[CsvReader] = csv_array_analysis
+array_analysis.array_analysis_extensions[CsvReader] = csv_array_analysis
 
 
 def csv_distributed_analysis(csv_node, array_dists):
@@ -185,10 +187,10 @@ def csv_usedefs(csv_node, use_set=None, def_set=None):
     def_set.update({v.name for v in csv_node.out_vars})
     use_set.add(csv_node.file_name.name)
 
-    return numba.analysis._use_defs_result(usemap=use_set, defmap=def_set)
+    return analysis._use_defs_result(usemap=use_set, defmap=def_set)
 
 
-numba.analysis.ir_extension_usedefs[CsvReader] = csv_usedefs
+analysis.ir_extension_usedefs[CsvReader] = csv_usedefs
 
 
 def get_copies_csv(csv_node, typemap):

--- a/sdc/io/np_io.py
+++ b/sdc/io/np_io.py
@@ -28,12 +28,13 @@
 import numpy as np
 import numba
 import sdc
-from numba import types, cgutils
-from numba.targets.arrayobj import make_array
+from numba import types
+from numba.core import cgutils
+from numba.np.arrayobj import make_array
 from numba.extending import overload, intrinsic, overload_method
 from sdc.str_ext import string_type
 
-from numba.ir_utils import (compile_to_numba_ir, replace_arg_nodes,
+from numba.core.ir_utils import (compile_to_numba_ir, replace_arg_nodes,
                             find_callname, guard)
 
 _get_file_size = types.ExternalFunction("get_file_size", types.int64(types.voidptr))

--- a/sdc/io/parquet_pio.py
+++ b/sdc/io/parquet_pio.py
@@ -28,21 +28,22 @@
 from sdc.config import _has_pyarrow
 import llvmlite.binding as ll
 from llvmlite import ir as lir
-from numba.targets.arrayobj import make_array
-from numba.targets.imputils import lower_builtin
-from numba import cgutils
+from numba.np.arrayobj import make_array
+from numba.core.imputils import lower_builtin
+from numba.core import cgutils
 import numba
-from numba import ir, config, ir_utils, types
-from numba.ir_utils import (mk_unique_var, replace_vars_inner, find_topo_order,
+from numba import config, types
+from numba.core import ir, ir_utils
+from numba.core.ir_utils import (mk_unique_var, replace_vars_inner, find_topo_order,
                             dprint_func_ir, remove_dead, mk_alloc, remove_dels,
                             get_name_var_table, replace_var_names,
                             add_offset_to_labels, get_ir_of_code,
                             compile_to_numba_ir, replace_arg_nodes,
                             find_callname, guard, require, get_definition)
 
-from numba.typing.templates import infer_global, AbstractTemplate
-from numba.typing import signature
-from numba.targets.imputils import impl_ret_new_ref, impl_ret_borrowed
+from numba.core.typing.templates import infer_global, AbstractTemplate
+from numba.core.typing import signature
+from numba.core.imputils import impl_ret_new_ref, impl_ret_borrowed
 import numpy as np
 import sdc
 from sdc.str_ext import string_type, unicode_to_char_ptr
@@ -90,7 +91,7 @@ def remove_parquet(rhs, lives, call_list):
     return False
 
 
-numba.ir_utils.remove_call_handlers.append(remove_parquet)
+numba.core.ir_utils.remove_call_handlers.append(remove_parquet)
 
 
 class ParquetHandler(object):

--- a/sdc/rewrites/dataframe_constructor.py
+++ b/sdc/rewrites/dataframe_constructor.py
@@ -25,9 +25,9 @@
 # *****************************************************************************
 
 
-from numba.rewrites import (register_rewrite, Rewrite)
-from numba.ir_utils import (guard, find_callname)
-from numba.ir import (Expr)
+from numba.core.rewrites import (register_rewrite, Rewrite)
+from numba.core.ir_utils import (guard, find_callname)
+from numba.core.ir import (Expr)
 from numba.extending import overload
 
 from pandas import DataFrame

--- a/sdc/rewrites/dataframe_getitem_attribute.py
+++ b/sdc/rewrites/dataframe_getitem_attribute.py
@@ -24,11 +24,11 @@
 # EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # *****************************************************************************
 
-from numba.ir import Assign, Const, Expr, Var
-from numba.ir_utils import mk_unique_var
-from numba.rewrites import register_rewrite, Rewrite
-from numba.types import StringLiteral
-from numba.typing import signature
+from numba.core.ir import Assign, Const, Expr, Var
+from numba.core.ir_utils import mk_unique_var
+from numba.core.rewrites import register_rewrite, Rewrite
+from numba.core.types import StringLiteral
+from numba.core.typing import signature
 
 from sdc.config import config_pipeline_hpat_default
 from sdc.hiframes.pd_dataframe_type import DataFrameType

--- a/sdc/rewrites/ir_utils.py
+++ b/sdc/rewrites/ir_utils.py
@@ -28,10 +28,10 @@ from sys import modules
 
 from types import FunctionType
 
-from numba.ir import (Const, Global, Var, FreeVar,
+from numba.core.ir import (Const, Global, Var, FreeVar,
                       Expr, Assign, Del,
                       unknown_loc)
-from numba.ir_utils import (guard, find_const, mk_unique_var)
+from numba.core.ir_utils import (guard, find_const, mk_unique_var)
 from numba.extending import _Intrinsic
 
 

--- a/sdc/rewrites/read_csv_consts.py
+++ b/sdc/rewrites/read_csv_consts.py
@@ -24,18 +24,20 @@
 # EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # *****************************************************************************
 
-from numba.rewrites import register_rewrite, Rewrite
-from numba.ir_utils import find_callname, guard, mk_unique_var
-from numba import ir, errors, consts
+from numba.core.rewrites import register_rewrite, Rewrite
+from numba.core.ir_utils import find_callname, guard, mk_unique_var
+from numba import errors
+from numba.core import ir
+from numba.core import consts
 
 from sdc.rewrites.ir_utils import remove_unused_recursively, make_assign, find_operations
 
 
 def find_build_sequence(func_ir, var):
-    """Reimplemented from numba.ir_utils.find_build_sequence
+    """Reimplemented from numba.core.ir_utils.find_build_sequence
     Added 'build_map' to build_ops list.
     """
-    from numba.ir_utils import (require, get_definition)
+    from numba.core.ir_utils import (require, get_definition)
 
     require(isinstance(var, ir.Var))
     var_def = get_definition(func_ir, var)

--- a/sdc/sdc_autogenerated.py
+++ b/sdc/sdc_autogenerated.py
@@ -36,7 +36,7 @@ import numpy
 import operator
 import pandas
 
-from numba.errors import TypingError
+from numba.core.errors import TypingError
 from numba import types
 
 from sdc.utilities.sdc_typing_utils import (TypeChecker, check_index_is_numeric, check_types_comparable,

--- a/sdc/sdc_function_templates.py
+++ b/sdc/sdc_function_templates.py
@@ -37,7 +37,7 @@ import numpy
 import operator
 import pandas
 
-from numba.errors import TypingError
+from numba.core.errors import TypingError
 from numba import types
 
 from sdc.utilities.sdc_typing_utils import (TypeChecker, check_index_is_numeric, check_types_comparable,

--- a/sdc/set_ext.py
+++ b/sdc/set_ext.py
@@ -33,14 +33,15 @@ from sdc.utilities.utils import to_array
 import sdc
 import operator
 import numba
-from numba import types, typing, generated_jit
+from numba import types, generated_jit
+from numba.core import typing
 from numba.extending import box, unbox, NativeValue
 from numba.extending import models, register_model
 from numba.extending import lower_builtin, overload_method, overload, intrinsic
-from numba.targets.imputils import (impl_ret_new_ref, impl_ret_borrowed,
+from numba.core.imputils import (impl_ret_new_ref, impl_ret_borrowed,
                                     iternext_impl, impl_ret_untracked, RefType)
-from numba import cgutils
-from numba.typing.templates import signature, AbstractTemplate, infer, infer_global
+from numba.core import cgutils
+from numba.core.typing.templates import signature, AbstractTemplate, infer, infer_global
 
 from llvmlite import ir as lir
 import llvmlite.binding as ll
@@ -278,11 +279,11 @@ def iternext_setiter(context, builder, sig, args, result):
     fnty = lir.FunctionType(lir.IntType(8).as_pointer(),
                             [lir.IntType(8).as_pointer()])
     fn = builder.module.get_or_insert_function(fnty, name="set_nextval_string")
-    kind = numba.unicode.PY_UNICODE_1BYTE_KIND
+    kind = numba.cpython.unicode.PY_UNICODE_1BYTE_KIND
 
     def std_str_to_unicode(std_str):
         length = sdc.str_ext.get_std_str_len(std_str)
-        ret = numba.unicode._empty_string(kind, length)
+        ret = numba.cpython.unicode._empty_string(kind, length)
         sdc.str_arr_ext._memcpy(
             ret._data, sdc.str_ext.get_c_str(std_str), length, 1)
         sdc.str_ext.del_str(std_str)

--- a/sdc/str_arr_ext.py
+++ b/sdc/str_arr_ext.py
@@ -35,16 +35,17 @@ import sdc
 from sdc import hstr_ext
 from glob import glob
 from llvmlite import ir as lir
-from numba import types, cgutils
+from numba import types
+from numba.core import cgutils
 from numba.extending import (typeof_impl, type_callable, models, register_model, NativeValue,
                              lower_builtin, box, unbox, lower_getattr, intrinsic,
                              overload_method, overload, overload_attribute)
-from numba.targets.hashing import _Py_hash_t
-from numba.targets.imputils import (impl_ret_new_ref, impl_ret_borrowed, iternext_impl, RefType)
-from numba.targets.listobj import ListInstance
-from numba.typing.templates import (infer_global, AbstractTemplate, infer,
+from numba.cpython.hashing import _Py_hash_t
+from numba.core.imputils import (impl_ret_new_ref, impl_ret_borrowed, iternext_impl, RefType)
+from numba.cpython.listobj import ListInstance
+from numba.core.typing.templates import (infer_global, AbstractTemplate, infer,
                                     signature, AttributeTemplate, infer_getattr, bound_function)
-from numba.special import prange
+from numba import prange
 
 from sdc.str_ext import string_type
 from sdc.str_arr_type import (StringArray, string_array_type, StringArrayType,
@@ -108,8 +109,7 @@ class StrArrayIteratorModel(models.StructModel):
                    ('array', string_array_type)]
         super(StrArrayIteratorModel, self).__init__(dmm, fe_type, members)
 
-
-lower_builtin('getiter', string_array_type)(numba.targets.arrayobj.getiter_array)
+lower_builtin('getiter', string_array_type)(numba.np.arrayobj.getiter_array)
 
 lower_builtin('iternext', StringArrayIterator)(iternext_impl(RefType.NEW)(iternext_str_array))
 
@@ -1052,7 +1052,7 @@ def str_arr_getitem_int(A, arg):
             length = end_offset - start_offset
             ptr = get_data_ptr_ind(A, start_offset)
             ret = decode_utf8(ptr, length)
-            # ret = numba.unicode._empty_string(kind, length)
+            # ret = numba.cpython.unicode._empty_string(kind, length)
             # _memcpy(ret._data, ptr, length, 1)
             return ret
 
@@ -1118,12 +1118,12 @@ def decode_utf8(typingctx, ptr_t, len_t=None):
 # def lower_string_arr_getitem(context, builder, sig, args):
 #     # TODO: support multibyte unicode
 #     # TODO: support Null
-#     kind = numba.unicode.PY_UNICODE_1BYTE_KIND
+#     kind = numba.cpython.unicode.PY_UNICODE_1BYTE_KIND
 #     def str_arr_getitem_impl(A, i):
 #         start_offset = getitem_str_offset(A, i)
 #         end_offset = getitem_str_offset(A, i + 1)
 #         length = end_offset - start_offset
-#         ret = numba.unicode._empty_string(kind, length)
+#         ret = numba.cpython.unicode._empty_string(kind, length)
 #         ptr = get_data_ptr_ind(A, start_offset)
 #         _memcpy(ret._data, ptr, length, 1)
 #         return ret
@@ -1211,8 +1211,8 @@ if sdc.config.config_pipeline_hpat_default:
 def lower_string_arr_getitem_slice(context, builder, sig, args):
     def str_arr_slice_impl(str_arr, idx):
         n = len(str_arr)
-        slice_idx = numba.unicode._normalize_slice(idx, n)
-        span = numba.unicode._slice_span(slice_idx)
+        slice_idx = numba.cpython.unicode._normalize_slice(idx, n)
+        span = numba.cpython.unicode._slice_span(slice_idx)
 
         if slice_idx.step == 1:
             start_offset = getitem_str_offset(str_arr, slice_idx.start)
@@ -1278,7 +1278,7 @@ def _str_arr_item_to_numeric(typingctx, out_ptr_t, str_arr_t, ind_t,
 # TODO: support array of strings
 # @typeof_impl.register(np.ndarray)
 # def typeof_np_string(val, c):
-#     arr_typ = numba.typing.typeof._typeof_ndarray(val, c)
+#     arr_typ = numba.core.typing.typeof._typeof_ndarray(val, c)
 #     # match string dtype
 #     if isinstance(arr_typ.dtype, (types.UnicodeCharSeq, types.CharSeq)):
 #         return string_array_type

--- a/sdc/tests/test_dataframe.py
+++ b/sdc/tests/test_dataframe.py
@@ -33,9 +33,9 @@ import string
 import unittest
 from itertools import permutations, product
 from numba import types
-from numba.config import IS_32BITS
-from numba.special import literal_unroll
-from numba.errors import TypingError
+from numba.core.config import IS_32BITS
+from numba import literal_unroll
+from numba.core.errors import TypingError
 
 import sdc
 from sdc.datatypes.common_functions import SDCLimitation

--- a/sdc/tests/test_io.py
+++ b/sdc/tests/test_io.py
@@ -31,7 +31,7 @@ import platform
 import pyarrow.parquet as pq
 import unittest
 import numba
-from numba.config import IS_32BITS
+from numba.core.config import IS_32BITS
 from pandas.api.types import CategoricalDtype
 
 import sdc

--- a/sdc/tests/test_rolling.py
+++ b/sdc/tests/test_rolling.py
@@ -35,7 +35,7 @@ from itertools import product
 import numpy as np
 import pandas as pd
 
-from numba.errors import TypingError
+from numba.core.errors import TypingError
 from sdc.hiframes.rolling import supported_rolling_funcs
 from sdc.tests.test_base import TestCase
 from sdc.tests.test_series import gen_frand_array

--- a/sdc/tests/test_series.py
+++ b/sdc/tests/test_series.py
@@ -34,10 +34,11 @@ import sdc
 import string
 import unittest
 from itertools import combinations, combinations_with_replacement, islice, permutations, product
+import numba
 from numba import types
-from numba.config import IS_32BITS
-from numba.errors import TypingError
-from numba.special import literally
+from numba.core.config import IS_32BITS
+from numba.core.errors import TypingError
+from numba import literally
 
 from sdc.tests.test_series_apply import TestSeries_apply
 from sdc.tests.test_series_map import TestSeries_map
@@ -5891,7 +5892,7 @@ class TestSeries(
 
     @skip_numba_jit('Numba propagates different exception:\n'
                     'numba.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)\n'
-                    'Internal error at <numba.typeinfer.IntrinsicCallConstraint ...\n'
+                    'Internal error at <numba.core.typeinfer.IntrinsicCallConstraint ...\n'
                     '\'Signature\' object is not iterable')
     @skip_sdc_jit('Typing checks not implemented for Series operators in old-style')
     def test_series_operator_lt_index_mismatch3(self):
@@ -5952,7 +5953,7 @@ class TestSeries(
 
     @skip_numba_jit('Numba propagates different exception:\n'
                     'numba.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)\n'
-                    'Internal error at <numba.typeinfer.IntrinsicCallConstraint ...\n'
+                    'Internal error at <numba.core.typeinfer.IntrinsicCallConstraint ...\n'
                     '\'Signature\' object is not iterable')
     @skip_sdc_jit('Typing checks not implemented for Series operators in old-style')
     def test_series_operator_lt_unsupported_dtypes(self):

--- a/sdc/utilities/sdc_typing_utils.py
+++ b/sdc/utilities/sdc_typing_utils.py
@@ -35,8 +35,8 @@ import numba
 import sdc
 
 from numba import types
-from numba.errors import TypingError
-from numba import numpy_support
+from numba.core.errors import TypingError
+from numba.np import numpy_support
 
 from sdc.str_arr_type import string_array_type
 


### PR DESCRIPTION
This PR eliminates warning about importing relocated modules from Numba using old paths.