### PR TITLE
Redesign DataFrame structure

### DIFF
--- a/sdc/hiframes/pd_dataframe_ext.py
+++ b/sdc/hiframes/pd_dataframe_ext.py
@@ -66,6 +66,28 @@ def init_dataframe(typingctx, *args):
     index_typ = args[n_cols]
     column_names = tuple(a.literal_value for a in args[n_cols + 1:])
 
+    # Define df structure, map column name to column position ex. {'A': (0,0), 'B': (1,0), 'C': (0,1)}
+    df_structure = {}
+    # Store unique types of columns ex. {'int64': (0, [0, 2]), 'float64': (1, [1])}
+    data_typs_map = {}
+    type_id = 0
+    for col_id, col_typ in enumerate(data_typs):
+        col_name = column_names[col_id]
+
+        if col_typ not in data_typs_map:
+            data_typs_map[col_typ] = (type_id, [col_id])
+            # The first column in each type always has 0 index
+            df_structure[col_name] = (type_id, 0)
+        else:
+            # Get index of column in list of types
+            col_idx_list = len(data_typs_map[col_typ][1])
+            type_id = data_typs_map[col_typ][0]
+            df_structure[col_name] = (type_id,  col_idx_list)
+
+            data_typs_map[col_typ][1].append(col_id)
+
+        type_id += 1
+
     def codegen(context, builder, signature, args):
         in_tup = args[0]
         data_arrs = [builder.extract_value(in_tup, i) for i in range(n_cols)]
@@ -76,10 +98,23 @@ def init_dataframe(typingctx, *args):
         dataframe = cgutils.create_struct_proxy(
             signature.return_type)(context, builder)
 
+        data_list_type = [types.List(typ) for typ in data_typs_map.keys()]
+
+        data_lists = []
+        for typ_id, typ in enumerate(data_typs_map.keys()):
+            data_list_typ = context.build_list(builder, data_list_type[typ_id],
+                                               [data_arrs[data_id] for data_id in data_typs_map[typ][1]])
+            data_lists.append(data_list_typ)
+
         data_tup = context.make_tuple(
-            builder, types.Tuple(data_typs), data_arrs)
+            builder, types.Tuple(data_list_type), data_lists)
+
+        col_list_type = types.List(string_type)
+        column_list = context.build_list(builder, col_list_type, column_strs)
+
         column_tup = context.make_tuple(
-            builder, types.UniTuple(string_type, n_cols), column_strs)
+            builder, types.UniTuple(col_list_type, 1), [column_list])
+
         zero = context.get_constant(types.int8, 0)
 
         dataframe.data = data_tup
@@ -97,7 +132,7 @@ def init_dataframe(typingctx, *args):
 
         return dataframe._getvalue()
 
-    ret_typ = DataFrameType(data_typs, index_typ, column_names)
+    ret_typ = DataFrameType(data_typs, index_typ, column_names, df_structure=df_structure)
     sig = signature(ret_typ, types.Tuple(args))
     return sig, codegen
 


### PR DESCRIPTION
Extension for [#801](https://github.com/IntelPython/sdc/pull/801)

- Implementation of new DataFrame structure based on lists instead of tuples
- Improved df.count() codegen for testing

Example:
```
df = pd.DataFrame({'A': [1,2,3], 'B': [.5, .6, .7], 'C': [4, 5, 6], 'D': ['a', 'b', 'c']})

(['A', 'B', 'C', 'D'],)
([array([1, 2, 3], dtype=int64), array([4, 5, 6], dtype=int64)], [array([0.5, 0.6, 0.7])], [array(['a', 'b', 'c'], dtype=object)])
```

Reproduce:
```
@njit
def run_df():
    df = pd.DataFrame({'A': [1,2,3], 'B': [.5, .6, .7], 'C': [4, 5, 6], 'D': ['a', 'b', 'c']})

    print(df._columns)
    print(df._data)

    return df.count()

```