### PR TITLE
Specify sdc version from channel for examples testing

### DIFF
--- a/buildscripts/run_examples.py
+++ b/buildscripts/run_examples.py
@@ -90,6 +90,7 @@ if __name__ == '__main__':
     sdc_utils.log_info('Run Intel(R) SDC examples', separate=True)
     sdc_utils.log_info(sdc_utils.line_double)
     sdc_utils.create_environment()
-    sdc_utils.install_conda_package(['sdc'])
+    sdc_package = f'sdc={sdc_utils.get_sdc_version_from_channel()}'
+    sdc_utils.install_conda_package([sdc_package])
 
     run_examples(sdc_utils)

--- a/buildscripts/utilities.py
+++ b/buildscripts/utilities.py
@@ -26,6 +26,7 @@
 
 
 
+import json
 import os
 import platform
 import re
@@ -87,7 +88,7 @@ class SDC_Build_Utilities:
         # Create Intel SDC environment
         create_args = ['-q', '-y', '-n', self.env_name, f'python={self.python}']
         create_args += packages_list + self.channel_list + ['--override-channels']
-        self.__run_conda_command(Conda_Commands.CREATE, create_args)
+        log_info(self.__run_conda_command(Conda_Commands.CREATE, create_args))
 
         return
 
@@ -97,7 +98,7 @@ class SDC_Build_Utilities:
         self.log_info(f'Install {" ".join(packages_list)} to {self.env_name} conda environment')
         install_args = ['-n', self.env_name]
         install_args += self.channel_list + ['--override-channels', '-q', '-y'] + packages_list
-        self.__run_conda_command(Conda_Commands.INSTALL, install_args)
+        log_info(self.__run_conda_command(Conda_Commands.INSTALL, install_args))
 
         return
 
@@ -135,3 +136,19 @@ class SDC_Build_Utilities:
         if separate:
             print(f'{time.strftime("%d/%m/%Y %H:%M:%S")}: {self.line_double}', flush=True)
         print(f'{time.strftime("%d/%m/%Y %H:%M:%S")}: {msg}', flush=True)
+
+    def get_sdc_version_from_channel(self):
+        python_version = f'py{self.python.replace('.', '')}'
+
+        # Get Intel SDC version from first channel in channel_list
+        search_args = ['sdc', '-c', self.channel_list[1], '--override-channels', '--json']
+        search_result = self.__run_conda_command(Conda_Commands.SEARCH, search_args)
+
+        repo_data = json.loads(search_result)
+        for package_data in repo_data['sdc']:
+            sdc_version = package_data['version']
+            sdc_build = package_data['build']
+            if python_version in sdc_build:
+                break
+
+        return f'{sdc_version}={sdc_build}'

--- a/buildscripts/utilities.py
+++ b/buildscripts/utilities.py
@@ -138,7 +138,7 @@ class SDC_Build_Utilities:
         print(f'{time.strftime("%d/%m/%Y %H:%M:%S")}: {msg}', flush=True)
 
     def get_sdc_version_from_channel(self):
-        python_version = f'py{self.python.replace('.', '')}'
+        python_version = 'py' + self.python.replace('.', '')
 
         # Get Intel SDC version from first channel in channel_list
         search_args = ['sdc', '-c', self.channel_list[1], '--override-channels', '--json']

--- a/buildscripts/utilities.py
+++ b/buildscripts/utilities.py
@@ -88,7 +88,7 @@ class SDC_Build_Utilities:
         # Create Intel SDC environment
         create_args = ['-q', '-y', '-n', self.env_name, f'python={self.python}']
         create_args += packages_list + self.channel_list + ['--override-channels']
-        log_info(self.__run_conda_command(Conda_Commands.CREATE, create_args))
+        self.log_info(self.__run_conda_command(Conda_Commands.CREATE, create_args))
 
         return
 
@@ -98,7 +98,7 @@ class SDC_Build_Utilities:
         self.log_info(f'Install {" ".join(packages_list)} to {self.env_name} conda environment')
         install_args = ['-n', self.env_name]
         install_args += self.channel_list + ['--override-channels', '-q', '-y'] + packages_list
-        log_info(self.__run_conda_command(Conda_Commands.INSTALL, install_args))
+        self.log_info(self.__run_conda_command(Conda_Commands.INSTALL, install_args))
 
         return
 


### PR DESCRIPTION
It occurs that conda resolver can take Intel SDC package
not from first channel where it is found.
Specify particular SDC version to avoid this in examples
for now.
Also print info for environment creation and package installing