### PR TITLE
Remove pin_compatible; introduces conflicts when building

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
 
   run:
     - python
-    - {{ pin_compatible('numpy') }}
+    - numpy
     - pandas  {{ PANDAS_VERSION }}
     - pyarrow {{ PYARROW_VERSION }}
     - numba   {{ NUMBA_VERSION }}


### PR DESCRIPTION
When building our distribution, conflicts seem to appear when pin_compatible('numpy') is used. Removing this to get Windows full builds to work.