### PR TITLE
SAT-2855 - Memory leaks cause segfaults in unit tests

### DIFF
--- a/sdc/hiframes/api.py
+++ b/sdc/hiframes/api.py
@@ -33,7 +33,7 @@ from numba.parfors import array_analysis
 from numba.core.typing import signature
 from numba.core.typing.templates import infer_global, AbstractTemplate, CallableTemplate
 from numba.extending import overload, intrinsic
-from numba.core.imputils import (lower_builtin, impl_ret_borrowed)
+from numba.core.imputils import (lower_builtin, impl_ret_borrowed, impl_ret_new_ref)
 
 import sdc
 from sdc.str_ext import string_type, list_string_array_type
@@ -168,7 +168,7 @@ class FixDfArrayType(AbstractTemplate):
 def lower_fix_df_array(context, builder, sig, args):
     func = fix_df_array_overload(sig.args[0])
     res = context.compile_internal(builder, func, sig, args)
-    return impl_ret_borrowed(context, builder, sig.return_type, res)
+    return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 
 def fix_df_array_overload(column):

--- a/sdc/hiframes/boxing.py
+++ b/sdc/hiframes/boxing.py
@@ -338,16 +338,21 @@ def unbox_series(typ, val, c):
     if typ.index == string_array_type:
         index_obj = c.pyapi.object_getattr_string(val, "index")
         series.index = unbox_str_series(string_array_type, index_obj, c).value
+        c.pyapi.decref(index_obj)
 
     if isinstance(typ.index, types.Array):
         index_obj = c.pyapi.object_getattr_string(val, "index")
         index_data = c.pyapi.object_getattr_string(index_obj, "_data")
         series.index = unbox_array(typ.index, index_data, c).value
+        c.pyapi.decref(index_obj)
+        c.pyapi.decref(index_data)
 
     if typ.is_named:
         name_obj = c.pyapi.object_getattr_string(val, "name")
         series.name = numba.cpython.unicode.unbox_unicode_str(
             string_type, name_obj, c).value
+        c.pyapi.decref(name_obj)
+
     # TODO: handle index and name
     c.pyapi.decref(arr_obj)
     return NativeValue(series._getvalue())

--- a/sdc/str_arr_ext.py
+++ b/sdc/str_arr_ext.py
@@ -884,7 +884,7 @@ def box_str_arr(typ, val, c):
                                   string_array.data, string_array.null_bitmap])
 
     # TODO: double check refcounting here
-    # c.context.nrt.decref(c.builder, typ, val)
+    c.context.nrt.decref(c.builder, typ, val)
     return arr  # c.builder.load(arr)
 
 


### PR DESCRIPTION
This PR solves issues with leaked Series data/indexes allocated in unit tests and not freed later, due to excessive increfs/missed decrefs. Running the same tests that create series from different inputs multiple times, shows that memory grows without fix and the fix resolves this.