### PR TITLE
Example of using jitted_function.py_func() for tests.

### DIFF
--- a/sdc/tests/test_series.py
+++ b/sdc/tests/test_series.py
@@ -2388,12 +2388,12 @@ class TestSeries(
                     self.assertAlmostEqual(actual, expected)
 
     def test_series_prod_skipna_default(self):
+        @self.jit
         def test_impl(S):
             return S.prod()
-        hpat_func = self.jit(test_impl)
 
         S = pd.Series([np.nan, 2, 3.])
-        self.assertEqual(hpat_func(S), test_impl(S))
+        self.assertEqual(test_impl(S), test_impl.py_func(S))
 
     def test_series_count1(self):
         def test_impl(S):


### PR DESCRIPTION
This PR shows that it is possible to get Python function from jitted function via `.py_func()`.
It could be used in tests. Additional variable to storing jitted function (like `hpat_func`) will not be required.