### PR TITLE
Increasing CI timeouts

### DIFF
--- a/buildscripts/azure/template-linux-macos.yml
+++ b/buildscripts/azure/template-linux-macos.yml
@@ -6,7 +6,7 @@ parameters:
 
 jobs:
 - job: ${{ parameters.name }}
-  timeoutInMinutes: 120
+  timeoutInMinutes: 180
   pool:
     vmImage: ${{ parameters.vmImage }}
   strategy:

--- a/buildscripts/azure/template-windows.yml
+++ b/buildscripts/azure/template-windows.yml
@@ -6,7 +6,7 @@ parameters:
 
 jobs:
 - job: ${{ parameters.name }}
-  timeoutInMinutes: 120
+  timeoutInMinutes: 180
   pool: 
     vmImage: ${{ parameters.vmImage }}
   strategy:


### PR DESCRIPTION
Motivation: on Windows Azure jobs are cancelled since they cannot pass
in 2h time. As a temp solution increase timeouts until parallel test
execution is added.