### PR TITLE
Fix RangeIndex tests

### DIFF
--- a/sdc/extensions/indexes/range_index_ext.py
+++ b/sdc/extensions/indexes/range_index_ext.py
@@ -97,6 +97,7 @@ def pd_range_index_overload(start=None, stop=None, step=None, dtype=None, copy=F
         raise SDCLimitation(f"{_func_name} Unsupported parameter. Given 'fastpath': {fastpath}")
 
     dtype_is_np_int64 = dtype is types.NumberClass(types.int64)
+    dtype_is_np_int32 = dtype is types.NumberClass(types.int32)
     dtype_is_unicode_str = isinstance(dtype, (types.UnicodeType, types.StringLiteral))
     if not _check_dtype_param_type(dtype):
         ty_checker.raise_exc(dtype, 'int64 dtype', 'dtype')
@@ -125,9 +126,12 @@ def pd_range_index_overload(start=None, stop=None, step=None, dtype=None, copy=F
 
         if not (dtype is None
                 or dtype_is_unicode_str and dtype == 'int64'
-                or dtype_is_np_int64):
-            raise TypeError("Invalid to pass a non-int64 dtype to RangeIndex")
+                or dtype_is_unicode_str and dtype == 'int32'
+                or dtype_is_np_int64
+                or dtype_is_np_int32):
+            raise ValueError("Incorrect `dtype` passed: expected signed integer")
 
+        # TODO: add support of int32 type
         _start = types.int64(start) if start is not None else types.int64(0)
 
         if stop is None:

--- a/sdc/tests/test_indexes.py
+++ b/sdc/tests/test_indexes.py
@@ -196,21 +196,20 @@ class TestRangeIndex(TestCase):
         sdc_func = self.jit(test_impl)
 
         n = 11
-        supported_dtypes = [None, np.int64, 'int64']
+        supported_dtypes = [None, np.int64, 'int64', np.int32, 'int32']
         for dtype in supported_dtypes:
             with self.subTest(dtype=dtype):
                 result = sdc_func(n, dtype)
                 result_ref = test_impl(n, dtype)
                 pd.testing.assert_index_equal(result, result_ref)
 
-    @skip_pandas1
     def test_range_index_create_param_dtype_invalid(self):
         def test_impl(stop, dtype):
             return pd.RangeIndex(stop, dtype=dtype)
         sdc_func = self.jit(test_impl)
 
         n = 11
-        invalid_dtypes = ['float', np.int32, 'int32']
+        invalid_dtypes = ['float']
         for dtype in invalid_dtypes:
             with self.subTest(dtype=dtype):
                 with self.assertRaises(Exception) as context:


### PR DESCRIPTION
Pandas 1.0 supports int32 types in RangeIndex but SDC not:
- Remove int32 from invalid types
- Change Exception type and message