### PR TITLE
Changing csv_reader_py impl to return df from objmode

### DIFF
--- a/sdc/datatypes/hpat_pandas_functions.py
+++ b/sdc/datatypes/hpat_pandas_functions.py
@@ -45,6 +45,7 @@ from sdc.str_arr_ext import string_array_type
 
 from sdc.hiframes import join, aggregate, sort
 from sdc.types import CategoricalDtypeType, Categorical
+from sdc.datatypes.categorical.pdimpl import _reconstruct_CategoricalDtype
 
 
 def get_numba_array_types_for_csv(df):
@@ -307,8 +308,7 @@ def sdc_pandas_read_csv(
         if ctype == string_array_type:
             return str
         if isinstance(ctype, Categorical):
-            return pd.CategoricalDtype(categories=ctype.pd_dtype.categories,
-                                       ordered=None)
+            return _reconstruct_CategoricalDtype(ctype.pd_dtype)
         return numpy_support.as_dtype(dtype)
 
     py_col_dtypes = {cname: _get_py_col_dtype(ctype) for cname, ctype in zip(col_names, col_types)}

--- a/sdc/hiframes/pd_dataframe_ext.py
+++ b/sdc/hiframes/pd_dataframe_ext.py
@@ -26,7 +26,6 @@
 
 
 import operator
-from typing import NamedTuple
 
 import numba
 from numba import types
@@ -39,7 +38,7 @@ from numba.core.typing.templates import (infer_global, AbstractTemplate, signatu
 from numba.core.imputils import impl_ret_new_ref, impl_ret_borrowed
 
 from sdc.hiframes.pd_series_ext import SeriesType
-from sdc.hiframes.pd_dataframe_type import DataFrameType
+from sdc.hiframes.pd_dataframe_type import DataFrameType, ColumnLoc
 from sdc.str_ext import string_type
 
 
@@ -53,10 +52,6 @@ class DataFrameAttribute(AttributeTemplate):
             arr_typ = df.data[ind]
             return SeriesType(arr_typ.dtype, arr_typ, df.index, True)
 
-
-class ColumnLoc(NamedTuple):
-    type_id: int
-    col_id: int
 
 
 def get_structure_maps(col_types, col_names):

--- a/sdc/io/csv_ext.py
+++ b/sdc/io/csv_ext.py
@@ -24,7 +24,6 @@
 # EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # *****************************************************************************
 
-
 import contextlib
 import functools
 
@@ -45,6 +44,8 @@ from sdc import distributed, distributed_analysis
 from sdc.utilities.utils import (debug_prints, alloc_arr_tup, empty_like_type,
                                  _numba_to_c_type_map)
 from sdc.distributed_analysis import Distribution
+from sdc.hiframes.pd_dataframe_type import DataFrameType, ColumnLoc
+from sdc.hiframes.pd_dataframe_ext import get_structure_maps
 from sdc.str_ext import string_type
 from sdc.str_arr_ext import (string_array_type, to_string_list,
                               cp_str_list_to_array, str_list_to_array,
@@ -56,13 +57,14 @@ from sdc import objmode
 import pandas as pd
 import numpy as np
 
-from sdc.types import CategoricalDtypeType, Categorical
+from sdc.types import Categorical
 
 import pyarrow
 import pyarrow.csv
 
 
 class CsvReader(ir.Stmt):
+
     def __init__(self, file_name, df_out, sep, df_colnames, out_vars, out_types, usecols, loc, skiprows=0):
         self.file_name = file_name
         self.df_out = df_out
@@ -263,8 +265,10 @@ def csv_distributed_run(csv_node, array_dists, typemap, calltypes, typingctx, ta
     # get global array sizes by calling allreduce on chunk lens
     # TODO: get global size from C
     for arr in csv_node.out_vars:
+
         def f(A):
             return sdc.distributed_api.dist_reduce(len(A), np.int32(_op))
+
         f_block = compile_to_numba_ir(
             f, {'sdc': sdc, 'np': np,
                 '_op': sdc.distributed_api.Reduce_Type.Sum.value},
@@ -287,6 +291,7 @@ distributed.distributed_run_extensions[CsvReader] = csv_distributed_run
 
 
 class StreamReaderType(types.Opaque):
+
     def __init__(self):
         super(StreamReaderType, self).__init__(name='StreamReaderType')
 
@@ -298,25 +303,6 @@ register_model(StreamReaderType)(models.OpaqueModel)
 @box(StreamReaderType)
 def box_stream_reader(typ, val, c):
     return val
-
-
-def _get_dtype_str(t):
-    dtype = t.dtype
-
-    if isinstance(t, Categorical):
-        # return categorical representation
-        # for some reason pandas and pyarrow read_csv() return CategoricalDtype with
-        # ordered=False in case when dtype is with ordered=None
-        return str(t).replace('ordered=None', 'ordered=False')
-
-    if dtype == types.NPDatetime('ns'):
-        dtype = 'NPDatetime("ns")'
-    if t == string_array_type:
-        # HACK: add string_array_type to numba.types
-        # FIXME: fix after Numba #3372 is resolved
-        types.string_array_type = string_array_type
-        return 'string_array_type'
-    return '{}[::1]'.format(dtype)
 
 
 def _get_pd_dtype_str(t):
@@ -343,7 +329,7 @@ def to_varname(string):
     Replaces unavailable symbols with _ and insert _ if string starts with digit.
     """
     import re
-    return re.sub(r'\W|^(?=\d)','_', string)
+    return re.sub(r'\W|^(?=\d)', '_', string)
 
 
 @contextlib.contextmanager
@@ -358,10 +344,12 @@ def pyarrow_cpu_count(cpu_count=pyarrow.cpu_count()):
 
 def pyarrow_cpu_count_equal_numba_num_treads(func):
     """Decorator. Set pyarrow cpu_count the same as NUMBA_NUM_THREADS."""
+
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         with pyarrow_cpu_count(numba.config.NUMBA_NUM_THREADS):
             return func(*args, **kwargs)
+
     return wrapper
 
 
@@ -541,20 +529,27 @@ def pandas_read_csv(
     return dataframe
 
 
-def _gen_csv_reader_py_pyarrow(col_names, col_typs, usecols, sep, typingctx, targetctx, parallel, skiprows):
-    func_text, func_name = _gen_csv_reader_py_pyarrow_func_text(col_names, col_typs, usecols, sep, skiprows)
-    csv_reader_py = _gen_csv_reader_py_pyarrow_py_func(func_text, func_name)
-    return _gen_csv_reader_py_pyarrow_jit_func(csv_reader_py)
+def _gen_pandas_read_csv_func_text(col_names, col_typs, dtype_present, usecols, signature=None):
 
+    return_columns = usecols if usecols and isinstance(usecols[0], str) else col_names
 
-def _gen_csv_reader_py_pyarrow_func_text_core(col_names, col_typs, dtype_present, usecols, signature=None):
+    column_loc, _, _ = get_structure_maps(col_typs, return_columns)
+    df_type = DataFrameType(
+        tuple(col_typs),
+        types.none,
+        tuple(col_names),
+        column_loc=column_loc
+    )
+
+    df_type_repr = repr(df_type)
+    # for some reason pandas and pyarrow read_csv() return CategoricalDtype with
+    # ordered=False in case when dtype is with ordered=None
+    df_type_repr = df_type_repr.replace('ordered=None', 'ordered=False')
+
     # TODO: support non-numpy types like strings
     date_inds = ", ".join(str(i) for i, t in enumerate(col_typs) if t.dtype == types.NPDatetime('ns'))
     return_columns = usecols if usecols and isinstance(usecols[0], str) else col_names
-    nb_objmode_vars = ", ".join([
-        '{}="{}"'.format(to_varname(cname), _get_dtype_str(t))
-        for cname, t in zip(return_columns, col_typs)
-    ])
+
     pd_dtype_strs = ", ".join([
         "'{}': {}".format(cname, _get_pd_dtype_str(t))
         for cname, t in zip(return_columns, col_typs)
@@ -562,58 +557,48 @@ def _gen_csv_reader_py_pyarrow_func_text_core(col_names, col_typs, dtype_present
 
     if signature is None:
         signature = "filepath_or_buffer"
-    func_text = "def csv_reader_py({}):\n".format(signature)
-    func_text += "  with objmode({}):\n".format(nb_objmode_vars)
-    func_text += "    df = pandas_read_csv(filepath_or_buffer,\n"
+
+    # map generated func params into values used in inner call of pandas_read_csv
+    # if no transformation is needed just use outer param name (since APIs match)
+    # otherwise use value in the dictionary
+    inner_call_params = {'parse_dates': f"[{date_inds}]"}
+    used_read_csv_params = (
+        'filepath_or_buffer',
+        'names',
+        'skiprows',
+        'parse_dates',
+        'dtype',
+        'usecols',
+        'sep',
+        'delimiter'
+    )
 
     # pyarrow reads unnamed header as " ", pandas reads it as "Unnamed: N"
     # during inference from file names should be raplaced with "Unnamed: N"
     # passing names to pyarrow means that one row is header and should be skipped
     if col_names and any(map(lambda x: x.startswith('Unnamed: '), col_names)):
-        func_text += "        names={},\n".format(col_names)
-        func_text += "        skiprows=(skiprows and skiprows + 1) or 1,\n"
-    else:
-        func_text += "        names=names,\n"
-        func_text += "        skiprows=skiprows,\n"
-
-    func_text += "        parse_dates=[{}],\n".format(date_inds)
+        inner_call_params['names'] = str(col_names)
+        inner_call_params['skiprows'] = "(skiprows and skiprows + 1) or 1"
 
     # Python objects (e.g. str, np.float) could not be jitted and passed to objmode
     # so they are hardcoded to function
     # func_text += "        dtype={{{}}},\n".format(pd_dtype_strs) if dtype_present else \
     #              "        dtype=dtype,\n"
     # dtype is hardcoded because datetime should be read as string
-    func_text += "        dtype={{{}}},\n".format(pd_dtype_strs)
+    inner_call_params['dtype'] = f"{{{pd_dtype_strs}}}"
 
-    func_text += "        usecols=usecols,\n"
-    func_text += "        sep=sep,\n"
-    func_text += "        delimiter=delimiter,\n"
-    func_text += "    )\n"
-    for cname in return_columns:
-        func_text += "    {} = df['{}'].values\n".format(to_varname(cname), cname)
-        # func_text += "    print({})\n".format(cname)
+    params_str = '\n'.join([
+        f"      {param}={inner_call_params.get(param, param)}," for param in used_read_csv_params
+    ])
+    func_text = '\n'.join([
+        f"def csv_reader_py({signature}):",
+        f"  with objmode(df=\"{df_type_repr}\"):",
+        f"    df = pandas_read_csv(\n{params_str}",
+        f"    )",
+        f"  return df"
+    ])
+
     return func_text, 'csv_reader_py'
-
-
-def _gen_csv_reader_py_pyarrow_func_text(col_names, col_typs, usecols):
-    func_text, func_name = _gen_csv_reader_py_pyarrow_func_text_core(col_names, col_typs, usecols)
-
-    func_text += "  return ({},)\n".format(", ".join(to_varname(c) for c in col_names))
-
-    return func_text, func_name
-
-
-def _gen_csv_reader_py_pyarrow_func_text_dataframe(col_names, col_typs, dtype_present, usecols, signature):
-    func_text, func_name = _gen_csv_reader_py_pyarrow_func_text_core(
-        col_names, col_typs, dtype_present, usecols, signature)
-    return_columns = usecols if usecols and isinstance(usecols[0], str) else col_names
-
-    func_text += "  return sdc.hiframes.pd_dataframe_ext.init_dataframe({}, None, {})\n".format(
-        ", ".join(to_varname(c) for c in return_columns),
-        ", ".join("'{}'".format(c) for c in return_columns)
-    )
-
-    return func_text, func_name
 
 
 def _gen_csv_reader_py_pyarrow_py_func(func_text, func_name):
@@ -628,6 +613,3 @@ def _gen_csv_reader_py_pyarrow_jit_func(csv_reader_py):
     jit_func = numba.njit(csv_reader_py)
     compiled_funcs.append(jit_func)
     return jit_func
-
-
-_gen_csv_reader_py = _gen_csv_reader_py_pyarrow

--- a/sdc/str_arr_type.py
+++ b/sdc/str_arr_type.py
@@ -66,6 +66,8 @@ class StringArrayType(types.IterableType):
 
 
 string_array_type = StringArrayType()
+# FIXME_Numba#3372: add into numba.types to allow returning from objmode
+types.StringArrayType = StringArrayType
 
 
 class StringArrayPayloadType(types.Type):

--- a/sdc/tests/test_io.py
+++ b/sdc/tests/test_io.py
@@ -663,6 +663,8 @@ class TestCSV(TestIO):
 
         return test_impl
 
+    @skip_numba_jit("Lowering error while returning df from objmode:\n"
+                    "Can only insert i8* at [4] in {i8*, i8*, i64, i64, i8*, [1 x i64], [1 x i64]}: got i64*")
     def test_csv_cat1(self):
         test_impl = self.pd_csv_cat1()
         hpat_func = self.jit(test_impl)
@@ -682,6 +684,8 @@ class TestCSV(TestIO):
 
         return test_impl
 
+    @skip_numba_jit("Lowering error while returning df from objmode:\n"
+                    "Can only insert i8* at [4] in {i8*, i8*, i64, i64, i8*, [1 x i64], [1 x i64]}: got i64*")
     def test_csv_cat2(self):
         test_impl = self.pd_csv_cat2()
         hpat_func = self.jit(test_impl)


### PR DESCRIPTION
Motivation: returning Tuple of columns read from csv file with
pyarrow csv reader from objmode and further calling init_dataframe
ctor to create native DF turned out to be inefficient in sense of
LLVM IR size and compilation time. With this PR we now rely on DF
unboxing and return py DF from objmode.

**Compile time of read_csv + df.count():**
solutions\columns | 4 | 8 | 16 | 32 | 64 | 128 | 256
-- | -- | -- | -- | -- | -- | -- | --
Numba master + both SDC fixes   (2b8b0034d74) | 8.897234 | 9.306839 | 10.54691 | 12.52175 | 17.41399 | 30.47878 | 65.63396
Numba master + SDC fix #1 (964e498a9) | 9.283413 | 9.83861 | 13.30219 | 21.7165 | 53.07618 | 187.4615 | 1026.31
Numba 0.50.1  + SDC master | 9.212505 | 10.238 | 14.08183 | 25.16768 | 72.9872 | 290.3359 | 2141.832
Ratio (both fixes to master) | 1.035435 | 1.100051 | 1.335162 | 2.009917 | 4.191296 | 9.525835 | 32.63299




