### PR TITLE
Implements init_dataframe as multiple codegen functions

### DIFF
--- a/sdc/datatypes/hpat_pandas_dataframe_functions.py
+++ b/sdc/datatypes/hpat_pandas_dataframe_functions.py
@@ -1462,7 +1462,7 @@ def df_getitem_slice_idx_main_codelines(self, idx):
         res_data = f'res_data_{i}'
         func_lines += [
             f'  data_{i} = self._data[{type_id}][{col_id}][idx]',
-            f'  {res_data} = pandas.Series(data_{i}, index=res_index, name="{col}")'
+            f'  {res_data} = data_{i}'
         ]
         results.append((col, res_data))
 

--- a/sdc/hiframes/api.py
+++ b/sdc/hiframes/api.py
@@ -172,20 +172,20 @@ def fix_df_index(index, *columns):
 
 
 @overload(fix_df_index)
-def fix_df_index_overload(index, *columns):
+def fix_df_index_overload(index):
 
     # TO-DO: replace types.none index with separate type, e.g. DefaultIndex
     if (index is None or isinstance(index, types.NoneType)):
-        def fix_df_index_impl(index, *columns):
+        def fix_df_index_impl(index):
             return None
 
     elif isinstance(index, RangeIndexType):
-        def fix_df_index_impl(index, *columns):
+        def fix_df_index_impl(index):
             return index
 
     else:
         # default case, transform index the same as df data
-        def fix_df_index_impl(index, *columns):
+        def fix_df_index_impl(index):
             return fix_df_array(index)
 
     return fix_df_index_impl

--- a/sdc/hiframes/api.py
+++ b/sdc/hiframes/api.py
@@ -167,7 +167,7 @@ def fix_df_array_overload(column):
         return lambda column: column
 
 
-def fix_df_index(index, *columns):
+def fix_df_index(index):
     return index
 
 

--- a/sdc/hiframes/pd_series_ext.py
+++ b/sdc/hiframes/pd_series_ext.py
@@ -138,7 +138,7 @@ def pd_series_overload(data=None, index=None, dtype=None, name=None, copy=False,
     def hpat_pandas_series_ctor_impl(data=None, index=None, dtype=None, name=None, copy=False, fastpath=False):
 
         fix_data = sdc.hiframes.api.fix_df_array(data)
-        fix_index = sdc.hiframes.api.fix_df_index(index, fix_data)
+        fix_index = sdc.hiframes.api.fix_df_index(index)
         return sdc.hiframes.api.init_series(fix_data, fix_index, name)
 
     return hpat_pandas_series_ctor_impl

--- a/sdc/rewrites/dataframe_constructor.py
+++ b/sdc/rewrites/dataframe_constructor.py
@@ -95,8 +95,8 @@ class RewriteDataFrame(Rewrite):
             args_len = len(args['data'])
             func_name = f'init_dataframe_{args_len}'
 
-            injected_module = modules[pd_dataframe_ext_module.__name__]
-            init_df = getattr(injected_module, func_name, None)
+            # injected_module = modules[pd_dataframe_ext_module.__name__]
+            init_df = getattr(pd_dataframe_ext_module, func_name, None)
             if init_df is None:
                 init_df_text = gen_init_dataframe_text(func_name, args_len)
                 init_df = gen_init_dataframe_func(

--- a/sdc/rewrites/dataframe_constructor.py
+++ b/sdc/rewrites/dataframe_constructor.py
@@ -184,7 +184,7 @@ def gen_init_dataframe_text(func_name, n_cols):
     suffix = ('' if n_cols == 0 else ', ')
 
     func_text = dedent(
-    f'''
+        f'''
     @intrinsic
     def {func_name}(typingctx, {params}):
         """Create a DataFrame with provided data, index and columns values.
@@ -236,8 +236,8 @@ def gen_init_dataframe_text(func_name, n_cols):
 
             data_lists = []
             for typ_id, typ in enumerate(types_order):
-                data_list_typ = context.build_list(builder, data_list_type[typ_id],
-                                                   [data_arrs_transformed[data_id] for data_id in data_typs_map[typ][1]])
+                data_arrs_of_typ = [data_arrs_transformed[data_id] for data_id in data_typs_map[typ][1]]
+                data_list_typ = context.build_list(builder, data_list_type[typ_id], data_arrs_of_typ)
                 data_lists.append(data_list_typ)
 
             data_tup = context.make_tuple(

--- a/sdc/tests/test_dataframe.py
+++ b/sdc/tests/test_dataframe.py
@@ -251,7 +251,6 @@ class TestDataFrame(TestCase):
         hpat_func = self.jit(test_impl)
         pd.testing.assert_frame_equal(hpat_func(df), test_impl(df))
 
-    @skip_numba_jit
     def test_box1(self):
         def test_impl(n):
             df = pd.DataFrame({'A': np.ones(n), 'B': np.arange(n)})

--- a/sdc/tests/test_dataframe.py
+++ b/sdc/tests/test_dataframe.py
@@ -98,7 +98,7 @@ class TestDataFrame(TestCase):
         n = 11
         self.assertEqual(hpat_func(n), test_impl(n))
 
-    def test_create4(self):
+    def test_create_empty_df(self):
         """ Verifies empty DF can be created """
         def test_impl():
             df = pd.DataFrame({})
@@ -106,6 +106,22 @@ class TestDataFrame(TestCase):
         hpat_func = self.jit(test_impl)
 
         self.assertEqual(hpat_func(), test_impl())
+
+    def test_create_multiple_dfs(self):
+        """ Verifies generated dataframe ctor is added to pd_dataframe_ext module
+        correctly (and numba global context is refreshed), so that subsequent
+        compilations are not broken. """
+        def test_impl(a, b, c):
+            df1 = pd.DataFrame({'A': a, 'B': b})
+            df2 = pd.DataFrame({'C': c})
+            total_cols = len(df1.columns) + len(df2.columns)
+            return total_cols
+        hpat_func = self.jit(test_impl)
+
+        a1 = np.array([1, 2, 3, 4.0, 5])
+        a2 = [7, 6, 5, 4, 3]
+        a3 = ['a', 'b', 'c', 'd', 'e']
+        self.assertEqual(hpat_func(a1, a2, a3), test_impl(a1, a2, a3))
 
     def test_create_str(self):
         def test_impl():
@@ -168,7 +184,7 @@ class TestDataFrame(TestCase):
                 result_ref = test_impl(A, B, index)
                 pd.testing.assert_frame_equal(result, result_ref)
 
-    def test_create_empty_df(self):
+    def test_unbox_empty_df(self):
         def test_impl(df):
             return df
         sdc_func = self.jit(test_impl)

--- a/sdc/tests/test_dataframe.py
+++ b/sdc/tests/test_dataframe.py
@@ -98,6 +98,15 @@ class TestDataFrame(TestCase):
         n = 11
         self.assertEqual(hpat_func(n), test_impl(n))
 
+    def test_create4(self):
+        """ Verifies empty DF can be created """
+        def test_impl():
+            df = pd.DataFrame({})
+            return len(df)
+        hpat_func = self.jit(test_impl)
+
+        self.assertEqual(hpat_func(), test_impl())
+
     def test_create_str(self):
         def test_impl():
             df = pd.DataFrame({'A': ['a', 'b', 'c']})


### PR DESCRIPTION
Motivation: init_dataframe was implemented via Numba intrinsic taking *args,
which seems to generate redundant extractvalue/insertvalue LLVM
instructions, producing quadratic IR when number of DF columns grows and affecting
total compilation time of function that create large DFs. This PR
replaces singe init_dataframe with multiple functions basing on number of columns
in a DF which are generated at compile time, thus avoiding use of *args.

n_columns |   | 8 | 16 | 32 | 64 | 128 | 256 | 512
-- | -- | -- | -- | -- | -- | -- | -- | --
LLVM IR size, Mb | on master | 0.287622 | 0.55394 | 1.262865 | 3.383549 | 10.44003 | 35.79943 | 131.384
LLVM IR size, Mb | With PR #936 | 0.143275 | 0.209119 | 0.341938 | 0.608992 | 1.143528 | 2.220672 | 4.406426
ratio without/with |   | 2.007482 | 2.648924 | 3.693257 | 5.555986 | 9.12967 | 16.12099 | 29.81645
compilation time, s | on master | 0.521313 | 0.366884 | 0.67621 | 1.39326 | 4.603106 | 17.54948 | 126.7943
compilation time, s | With PR #936 | 0.683099 | 0.413965 | 0.450348 | 0.715598 | 1.454044 | 3.210638 | 6.943996
ratio without/with |   | 0.763159 | 0.886268 | 1.501529 | 1.946987 | 3.165726 | 5.466041 | 18.25956

