### PR TITLE
Fixing bug in stability of mergesort impl for StringArray

### DIFF
--- a/sdc/_str_ext.cpp
+++ b/sdc/_str_ext.cpp
@@ -31,6 +31,7 @@
 #include <string>
 #include <vector>
 #include <cmath>
+#include <algorithm>
 
 #include "_str_decode.cpp"
 
@@ -129,6 +130,7 @@ extern "C"
     npy_intp array_size(PyArrayObject* arr);
     void* array_getptr1(PyArrayObject* arr, npy_intp ind);
     void array_setitem(PyArrayObject* arr, char* p, PyObject* s);
+    void stable_argsort(char* data_ptr, uint32_t* in_offsets, int64_t len, int8_t ascending, uint64_t* result);
 
     PyMODINIT_FUNC PyInit_hstr_ext(void)
     {
@@ -201,6 +203,7 @@ extern "C"
         PyObject_SetAttrString(m, "array_setitem", PyLong_FromVoidPtr((void*)(&array_setitem)));
         PyObject_SetAttrString(m, "decode_utf8", PyLong_FromVoidPtr((void*)(&decode_utf8)));
         PyObject_SetAttrString(m, "get_utf8_size", PyLong_FromVoidPtr((void*)(&get_utf8_size)));
+        PyObject_SetAttrString(m, "stable_argsort", PyLong_FromVoidPtr((void*)(&stable_argsort)));
         return m;
     }
 
@@ -870,5 +873,36 @@ extern "C"
 
         return;
     }
+
+    void stable_argsort(char* data_ptr, uint32_t* in_offsets, int64_t len, int8_t ascending, uint64_t* result)
+    {
+        using str_index_pair_type = std::pair<std::string, int64_t>;
+        std::vector<str_index_pair_type> str_arr_indexed;
+        str_arr_indexed.reserve(len);
+
+        for (int64_t i=0; i < len; ++i)
+        {
+            uint32_t start = in_offsets[i];
+            uint32_t size = in_offsets[i + 1] - in_offsets[i];
+            str_arr_indexed.emplace_back(
+                    std::move(std::string(&data_ptr[start], size)),
+                    i
+            );
+        }
+
+        std::stable_sort(str_arr_indexed.begin(),
+                         str_arr_indexed.end(),
+                         [=](const str_index_pair_type& left, const str_index_pair_type& right){
+                            if (ascending)
+                                return left.first < right.first;
+                            else
+                                return left.first > right.first;
+                         }
+        );
+
+        for (int64_t i=0; i < len; ++i)
+            result[i] = str_arr_indexed[i].second;
+    }
+
 
 } // extern "C"

--- a/sdc/datatypes/hpat_pandas_series_functions.py
+++ b/sdc/datatypes/hpat_pandas_series_functions.py
@@ -3949,11 +3949,9 @@ def hpat_pandas_series_sort_values(self, axis=0, ascending=True, inplace=False, 
         good = ~data_nan_mask
 
         if kind_is_none_or_default == True:  # noqa
-            argsort_res = sdc_arrays_argsort(self._data[good], kind='quicksort')
+            argsort_res = sdc_arrays_argsort(self._data[good], kind='quicksort', ascending=ascending)
         else:
-            argsort_res = sdc_arrays_argsort(self._data[good], kind=kind)
-        if not ascending:
-            argsort_res = argsort_res[::-1]
+            argsort_res = sdc_arrays_argsort(self._data[good], kind=kind, ascending=ascending)
 
         idx = numpy.arange(len(self), dtype=numpy.int32)
         sorted_index = numpy.empty(len(self), dtype=numpy.int32)

--- a/sdc/functions/numpy_like.py
+++ b/sdc/functions/numpy_like.py
@@ -1225,7 +1225,7 @@ def sort_overload(a, axis=-1, kind=None, order=None):
     return sort_impl
 
 
-def argsort(a, axis=-1, kind=None, order=None):
+def argsort(a, axis=-1, kind=None, order=None, ascending=True):
     """
     Returns the indices that would sort an array.
 
@@ -1254,7 +1254,7 @@ def argsort(a, axis=-1, kind=None, order=None):
 
 
 @sdc_overload(argsort)
-def argsort_overload(a, axis=-1, kind=None, order=None):
+def argsort_overload(a, axis=-1, kind=None, order=None, ascending=True):
     _func_name = 'argsort'
     ty_checker = TypeChecker(_func_name)
 
@@ -1266,15 +1266,15 @@ def argsort_overload(a, axis=-1, kind=None, order=None):
     if not is_default(order, None):
         raise TypingError(f'{_func_name} Unsupported parameter order')
 
-    def argsort_impl(a, axis=-1, kind=None, order=None):
+    def argsort_impl(a, axis=-1, kind=None, order=None, ascending=True):
         _kind = 'quicksort'
         if kind is not None:
             _kind = kind
 
         if _kind == 'quicksort':
-            return parallel_argsort(a)
+            return parallel_argsort(a, ascending)
         elif _kind == 'mergesort':
-            return parallel_stable_argsort(a)
+            return parallel_stable_argsort(a, ascending)
         else:
             raise ValueError("Unsupported value of 'kind' parameter")
 

--- a/sdc/native/module.cpp
+++ b/sdc/native/module.cpp
@@ -60,31 +60,31 @@ extern "C"
 
     void parallel_argsort_u64v(void* index, void* begin, uint64_t len, uint64_t size, void* compare);
 
-    void parallel_argsort_u64i8(void* index, void* begin, uint64_t len);
-    void parallel_argsort_u64u8(void* index, void* begin, uint64_t len);
-    void parallel_argsort_u64i16(void* index, void* begin, uint64_t len);
-    void parallel_argsort_u64u16(void* index, void* begin, uint64_t len);
-    void parallel_argsort_u64i32(void* index, void* begin, uint64_t len);
-    void parallel_argsort_u64u32(void* index, void* begin, uint64_t len);
-    void parallel_argsort_u64i64(void* index, void* begin, uint64_t len);
-    void parallel_argsort_u64u64(void* index, void* begin, uint64_t len);
+    void parallel_argsort_u64i8(void* index, void* begin, uint64_t len, uint8_t ascending);
+    void parallel_argsort_u64u8(void* index, void* begin, uint64_t len, uint8_t ascending);
+    void parallel_argsort_u64i16(void* index, void* begin, uint64_t len, uint8_t ascending);
+    void parallel_argsort_u64u16(void* index, void* begin, uint64_t len, uint8_t ascending);
+    void parallel_argsort_u64i32(void* index, void* begin, uint64_t len, uint8_t ascending);
+    void parallel_argsort_u64u32(void* index, void* begin, uint64_t len, uint8_t ascending);
+    void parallel_argsort_u64i64(void* index, void* begin, uint64_t len, uint8_t ascending);
+    void parallel_argsort_u64u64(void* index, void* begin, uint64_t len, uint8_t ascending);
 
-    void parallel_argsort_u64f32(void* index, void* begin, uint64_t len);
-    void parallel_argsort_u64f64(void* index, void* begin, uint64_t len);
+    void parallel_argsort_u64f32(void* index, void* begin, uint64_t len, uint8_t ascending);
+    void parallel_argsort_u64f64(void* index, void* begin, uint64_t len, uint8_t ascending);
 
     void parallel_stable_argsort_u64v(void* index, void* begin, uint64_t len, uint64_t size, void* compare);
 
-    void parallel_stable_argsort_u64i8(void* index, void* begin, uint64_t len);
-    void parallel_stable_argsort_u64u8(void* index, void* begin, uint64_t len);
-    void parallel_stable_argsort_u64i16(void* index, void* begin, uint64_t len);
-    void parallel_stable_argsort_u64u16(void* index, void* begin, uint64_t len);
-    void parallel_stable_argsort_u64i32(void* index, void* begin, uint64_t len);
-    void parallel_stable_argsort_u64u32(void* index, void* begin, uint64_t len);
-    void parallel_stable_argsort_u64i64(void* index, void* begin, uint64_t len);
-    void parallel_stable_argsort_u64u64(void* index, void* begin, uint64_t len);
+    void parallel_stable_argsort_u64i8(void* index, void* begin, uint64_t len, uint8_t ascending);
+    void parallel_stable_argsort_u64u8(void* index, void* begin, uint64_t len, uint8_t ascending);
+    void parallel_stable_argsort_u64i16(void* index, void* begin, uint64_t len, uint8_t ascending);
+    void parallel_stable_argsort_u64u16(void* index, void* begin, uint64_t len, uint8_t ascending);
+    void parallel_stable_argsort_u64i32(void* index, void* begin, uint64_t len, uint8_t ascending);
+    void parallel_stable_argsort_u64u32(void* index, void* begin, uint64_t len, uint8_t ascending);
+    void parallel_stable_argsort_u64i64(void* index, void* begin, uint64_t len, uint8_t ascending);
+    void parallel_stable_argsort_u64u64(void* index, void* begin, uint64_t len, uint8_t ascending);
 
-    void parallel_stable_argsort_u64f32(void* index, void* begin, uint64_t len);
-    void parallel_stable_argsort_u64f64(void* index, void* begin, uint64_t len);
+    void parallel_stable_argsort_u64f32(void* index, void* begin, uint64_t len, uint8_t ascending);
+    void parallel_stable_argsort_u64f64(void* index, void* begin, uint64_t len, uint8_t ascending);
 
     void set_number_of_threads(uint64_t threads)
     {

--- a/sdc/native/sort.cpp
+++ b/sdc/native/sort.cpp
@@ -92,8 +92,16 @@ void parallel_argsort_(I* index, void* data, uint64_t len, uint64_t size, compar
 } // namespace
 
 #define declare_single_argsort(index_prefix, type_prefix, ity, ty) \
-void parallel_argsort_##index_prefix##type_prefix(void* index, void* begin, uint64_t len) \
-{ parallel_argsort_(reinterpret_cast<ity*>(index), reinterpret_cast<ty*>(begin), len); }
+void parallel_argsort_##index_prefix##type_prefix(void* index, void* begin, uint64_t len, uint8_t ascending) \
+{ \
+    if (ascending) { \
+        auto cmp = utils::less<ty>(); \
+        parallel_argsort_(reinterpret_cast<ity*>(index), reinterpret_cast<ty*>(begin), len, cmp); \
+    } else { \
+        auto cmp = utils::greater<ty>(); \
+        parallel_argsort_(reinterpret_cast<ity*>(index), reinterpret_cast<ty*>(begin), len, cmp); \
+    } \
+}
 
 #define declare_argsort(prefix, ty) \
 declare_single_argsort(u8,  prefix, uint8_t,  ty) \

--- a/sdc/native/stable_sort.cpp
+++ b/sdc/native/stable_sort.cpp
@@ -281,8 +281,16 @@ struct parallel_sort_fixed_size
 } // namespace
 
 #define declare_single_argsort(index_prefix, type_prefix, ity, ty) \
-void parallel_stable_argsort_##index_prefix##type_prefix(ity* index, void* begin, uint64_t len) \
-{ parallel_stable_argsort_(reinterpret_cast<ity*>(index), reinterpret_cast<ty*>(begin), len); }
+void parallel_stable_argsort_##index_prefix##type_prefix(ity* index, void* begin, uint64_t len, uint8_t ascending) \
+{ \
+    if (ascending) { \
+        auto cmp = utils::less<ty>(); \
+        parallel_stable_argsort_(reinterpret_cast<ity*>(index), reinterpret_cast<ty*>(begin), len, cmp); \
+    } else { \
+        auto cmp = utils::greater<ty>(); \
+        parallel_stable_argsort_(reinterpret_cast<ity*>(index), reinterpret_cast<ty*>(begin), len, cmp); \
+    } \
+}
 
 #define declare_argsort(prefix, ty) \
 declare_single_argsort(u8,  prefix, uint8_t,  ty) \

--- a/sdc/native/utils.cpp
+++ b/sdc/native/utils.cpp
@@ -169,4 +169,16 @@ bool nanless<double>(const double& left, const double& right)
     return std::less<double>()(left, right) || (std::isnan(right) && !std::isnan(left));
 }
 
+template<>
+bool nangreater<float>(const float& left, const float& right)
+{
+    return std::greater<float>()(left, right) || (std::isnan(right) && !std::isnan(left));
+}
+
+template<>
+bool nangreater<double>(const double& left, const double& right)
+{
+    return std::greater<double>()(left, right) || (std::isnan(right) && !std::isnan(left));
+}
+
 }

--- a/sdc/native/utils.hpp
+++ b/sdc/native/utils.hpp
@@ -266,6 +266,27 @@ struct less
     }
 };
 
+template<typename T>
+bool nangreater(const T& left, const T& right)
+{
+    return std::greater<T>()(left, right);
+}
+
+template<>
+bool nangreater<float>(const float& left, const float& right);
+
+template<>
+bool nangreater<double>(const double& left, const double& right);
+
+template<typename T>
+struct greater
+{
+    bool operator() (const T& left, const T& right) const
+    {
+        return nangreater<T>(left, right);
+    }
+};
+
 namespace tbb_control
 {
     void init();

--- a/sdc/str_arr_ext.py
+++ b/sdc/str_arr_ext.py
@@ -54,6 +54,50 @@ from sdc.str_arr_type import (StringArray, string_array_type, StringArrayType,
 from sdc.utilities.sdc_typing_utils import check_is_array_of_dtype
 
 
+ll.add_symbol('get_str_len', hstr_ext.get_str_len)
+ll.add_symbol('allocate_string_array', hstr_ext.allocate_string_array)
+ll.add_symbol('setitem_string_array', hstr_ext.setitem_string_array)
+ll.add_symbol('getitem_string_array', hstr_ext.getitem_string_array)
+ll.add_symbol('getitem_string_array_std', hstr_ext.getitem_string_array_std)
+ll.add_symbol('is_na', hstr_ext.is_na)
+ll.add_symbol('string_array_from_sequence', hstr_ext.string_array_from_sequence)
+ll.add_symbol('np_array_from_string_array', hstr_ext.np_array_from_string_array)
+ll.add_symbol('print_int', hstr_ext.print_int)
+ll.add_symbol('convert_len_arr_to_offset', hstr_ext.convert_len_arr_to_offset)
+ll.add_symbol('set_string_array_range', hstr_ext.set_string_array_range)
+ll.add_symbol('str_arr_to_int64', hstr_ext.str_arr_to_int64)
+ll.add_symbol('str_arr_to_float64', hstr_ext.str_arr_to_float64)
+ll.add_symbol('dtor_string_array', hstr_ext.dtor_string_array)
+ll.add_symbol('c_glob', hstr_ext.c_glob)
+ll.add_symbol('decode_utf8', hstr_ext.decode_utf8)
+ll.add_symbol('get_utf8_size', hstr_ext.get_utf8_size)
+ll.add_symbol('stable_argsort', hstr_ext.stable_argsort)
+
+
+convert_len_arr_to_offset = types.ExternalFunction("convert_len_arr_to_offset",
+                                                   types.void(types.voidptr,
+                                                              types.intp))
+
+setitem_string_array = types.ExternalFunction("setitem_string_array",
+                                              types.void(types.voidptr,
+                                                         types.voidptr,
+                                                         types.intp,
+                                                         string_type,
+                                                         types.intp))
+
+_get_utf8_size = types.ExternalFunction("get_utf8_size",
+                                        types.intp(types.voidptr,  # data_ptr
+                                                   types.intp,     # length
+                                                   types.int32))   # kind
+
+_stable_argsort = types.ExternalFunction("stable_argsort",
+                                        types.void(types.intp,    # data_ptr
+                                                   types.intp,    # offset_ptr
+                                                   types.uint64,  # data size
+                                                   types.int8,    # ascending
+                                                   types.intp))   # result ptr
+
+
 @typeof_impl.register(StringArray)
 def typeof_string_array(val, c):
     return string_array_type
@@ -521,34 +565,6 @@ def str_arr_len_overload(str_arr):
         def str_arr_len(str_arr):
             return str_arr.size
         return str_arr_len
-
-
-ll.add_symbol('get_str_len', hstr_ext.get_str_len)
-ll.add_symbol('allocate_string_array', hstr_ext.allocate_string_array)
-ll.add_symbol('setitem_string_array', hstr_ext.setitem_string_array)
-ll.add_symbol('getitem_string_array', hstr_ext.getitem_string_array)
-ll.add_symbol('getitem_string_array_std', hstr_ext.getitem_string_array_std)
-ll.add_symbol('is_na', hstr_ext.is_na)
-ll.add_symbol('string_array_from_sequence', hstr_ext.string_array_from_sequence)
-ll.add_symbol('np_array_from_string_array', hstr_ext.np_array_from_string_array)
-ll.add_symbol('print_int', hstr_ext.print_int)
-ll.add_symbol('convert_len_arr_to_offset', hstr_ext.convert_len_arr_to_offset)
-ll.add_symbol('set_string_array_range', hstr_ext.set_string_array_range)
-ll.add_symbol('str_arr_to_int64', hstr_ext.str_arr_to_int64)
-ll.add_symbol('str_arr_to_float64', hstr_ext.str_arr_to_float64)
-ll.add_symbol('dtor_string_array', hstr_ext.dtor_string_array)
-ll.add_symbol('c_glob', hstr_ext.c_glob)
-ll.add_symbol('decode_utf8', hstr_ext.decode_utf8)
-ll.add_symbol('get_utf8_size', hstr_ext.get_utf8_size)
-
-convert_len_arr_to_offset = types.ExternalFunction("convert_len_arr_to_offset", types.void(types.voidptr, types.intp))
-
-
-setitem_string_array = types.ExternalFunction("setitem_string_array",
-                                              types.void(types.voidptr, types.voidptr, types.intp, string_type,
-                                                         types.intp))
-_get_utf8_size = types.ExternalFunction("get_utf8_size",
-                                        types.intp(types.voidptr, types.intp, types.int32))
 
 
 def construct_string_array(context, builder):
@@ -1444,3 +1460,14 @@ def sdc_str_arr_operator_is(context, builder, sig, args):
     ma = builder.ptrtoint(a.meminfo, cgutils.intp_t)
     mb = builder.ptrtoint(b.meminfo, cgutils.intp_t)
     return builder.icmp_signed('==', ma, mb)
+
+
+@numba.njit(no_cpython_wrapper=True)
+def str_arr_stable_argosort(arr, ascending=True):
+    argsort_res = np.empty(len(arr), dtype=np.int64)
+    _stable_argsort(get_data_ptr(arr).data,
+                    get_offset_ptr(arr).data,
+                    len(arr),
+                    types.int8(ascending),
+                    argsort_res.ctypes.data)
+    return argsort_res

--- a/sdc/tests/test_sdc_numpy.py
+++ b/sdc/tests/test_sdc_numpy.py
@@ -387,6 +387,46 @@ class TestArrays(TestCase):
                     with self.subTest(data=case, kind=kind, size=len(int_array)):
                         run_test(ref_impl, sdc_func, data, kind)
 
+    @unittest.expectedFailure  # expected to fail until pandas=1.2.0 (since pandas mergesort is not stable)
+    def test_argsort_param_ascending(self):
+
+        def ref_impl(a, kind, ascending):
+            return pd.Series(a).sort_values(kind=kind, ascending=ascending).index
+
+        def sdc_impl(a, kind, ascending):
+            return numpy_like.argsort(a, kind=kind, ascending=ascending)
+
+        def run_test(ref_impl, sdc_impl, data, kind, ascending):
+            if kind == 'mergesort':
+                np.testing.assert_array_equal(
+                    ref_impl(data, kind, ascending),
+                    sdc_func(data, kind, ascending))
+            else:
+                sorted_ref = data[ref_impl(data, kind, ascending)]
+                sorted_sdc = data[sdc_impl(data, kind, ascending)]
+                np.testing.assert_array_equal(sorted_ref, sorted_sdc)
+
+        sdc_func = self.jit(sdc_impl)
+
+        n = 100
+        np.random.seed(0)
+        data_values = {
+            'float': [np.inf, np.NINF, np.nan, 0, -1, 2.1, 2/3, -3/4, 0.777],
+            'int': [1, -1, 3, 5, -60, 21, 22, 23],
+        }
+        all_dtypes = {
+            'float': ['float32', 'float64'],
+            'int': ['int8', 'uint8', 'int16', 'uint16', 'int32', 'uint32', 'int64', 'uint64']
+        }
+
+        for kind, ascending in product([None, 'quicksort', 'mergesort'], [True, False]):
+            for dtype_group, arr_values in data_values.items():
+                for dtype in all_dtypes[dtype_group]:
+                    data = np.random.choice(arr_values, n).astype(dtype)
+                    with self.subTest(data=data, kind=kind, ascending=ascending):
+                        run_test(ref_impl, sdc_func, data, kind, ascending)
+
+
     def _test_fillna_numeric(self, pyfunc, cfunc, inplace):
         data_to_test = [
             [True, False, False, True, True],


### PR DESCRIPTION
Motivation: for StringArray type legacy implementation of stable sort
computed result when sorting with ascending=False by reversing the
result of argsorting with ascending=True, which produces wrong order in
groups of elements with the same value. Implemented solution adds
new function argument 'ascening' and uses it when calling native function
impl via serial stable_sort.