### PR TITLE
Moving to numba=0.53.1

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set NUMBA_VERSION = "==0.52.0" %}
+{% set NUMBA_VERSION = "==0.53.0" %}
 {% set PANDAS_VERSION = "==1.2.0" %}
 {% set PYARROW_VERSION = "==2.0.0" %}
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set NUMBA_VERSION = "==0.53.0" %}
+{% set NUMBA_VERSION = "==0.53.1" %}
 {% set PANDAS_VERSION = "==1.2.0" %}
 {% set PYARROW_VERSION = "==2.0.0" %}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.16
 pandas==1.2.0
 pyarrow==2.0.0
-numba==0.52.0
+numba==0.53.0
 tbb
 tbb-devel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.16
 pandas==1.2.0
 pyarrow==2.0.0
-numba==0.53.0
+numba==0.53.1
 tbb
 tbb-devel

--- a/sdc/functions/numpy_like.py
+++ b/sdc/functions/numpy_like.py
@@ -149,7 +149,7 @@ def sdc_astype_overload(self, dtype):
             arr_len = len(self)
 
             # Get total bytes for new array
-            for i in prange(arr_len):
+            for i in np.arange(arr_len):    # FIXME_Numba#6969: prange segfaults, use it when resolved
                 item = self[i]
                 num_bytes += get_utf8_size(str(item))
 

--- a/setup.py
+++ b/setup.py
@@ -382,7 +382,7 @@ setup(name=SDC_NAME_STR,
           'numpy>=1.16',
           'pandas==1.2.0',
           'pyarrow==2.0.0',
-          'numba==0.52.0',
+          'numba==0.53.0',
           'tbb'
           ],
       cmdclass=sdc_build_commands,

--- a/setup.py
+++ b/setup.py
@@ -382,7 +382,7 @@ setup(name=SDC_NAME_STR,
           'numpy>=1.16',
           'pandas==1.2.0',
           'pyarrow==2.0.0',
-          'numba==0.53.0',
+          'numba==0.53.1',
           'tbb'
           ],
       cmdclass=sdc_build_commands,


### PR DESCRIPTION
Motivation: keep up with latest Numba release.

Note: commit 2017e6c28d is actually just a workaround for numba=0.53.1 regressions and probably should be reverted once referred issues are fixed.