### PR TITLE
Dependency for numpy 1.17

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - python
     - setuptools
     - numba   {{ NUMBA_VERSION }}
-    - numpy
+    - numpy 1.17
     - pandas  {{ PANDAS_VERSION }}
     - pyarrow {{ PYARROW_VERSION }}
     - wheel

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -25,7 +25,8 @@ requirements:
     - python
     - setuptools
     - numba   {{ NUMBA_VERSION }}
-    - numpy 1.17
+    - numpy                           # [win or osx or py==38]
+    - numpy 1.17                      # [linux and py==37]
     - pandas  {{ PANDAS_VERSION }}
     - pyarrow {{ PYARROW_VERSION }}
     - wheel

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set NUMBA_VERSION = "==0.53.1" %}
-{% set PANDAS_VERSION = "==1.2.0" %}
+{% set PANDAS_VERSION = "==1.2.4" %}
 {% set PYARROW_VERSION = "==2.0.0" %}
 
 package:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set NUMBA_VERSION = "==0.53.1" %}
-{% set PANDAS_VERSION = "==1.2.4" %}
+{% set PANDAS_VERSION = "==1.2.0" %}
 {% set PYARROW_VERSION = "==2.0.0" %}
 
 package:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
 
   run:
     - python
-    - numpy
+    - {{ pin_compatible('numpy') }}
     - pandas  {{ PANDAS_VERSION }}
     - pyarrow {{ PYARROW_VERSION }}
     - numba   {{ NUMBA_VERSION }}


### PR DESCRIPTION
This PR is to follow Anaconda BKM to build using the oldest numpy with a stable API, which is 1.16. Intel's oldest numpy supporting python 3.7 is numpy 1.17, so we use that only at build time so ensure broadest compatibility with newer numpy versions.

Relates to https://github.com/tensorflow/tensorflow/issues/47691  (TensorFlow does not support numpy 1.20.x)