### PR TITLE
[WIP]: Tweak Int64Index.reindex() performance

### DIFF
--- a/sdc/extensions/indexes/indexes_generic.py
+++ b/sdc/extensions/indexes/indexes_generic.py
@@ -43,6 +43,7 @@ from sdc.utilities.sdc_typing_utils import (
 from sdc.hiframes.api import fix_df_index
 from sdc.functions import numpy_like
 from sdc.datatypes.common_functions import _sdc_internal_join
+from sdc.extensions.sdc_hashmap_type import ConcurrentDict
 
 
 def sdc_numeric_indexes_equals(left, right):
@@ -131,24 +132,20 @@ def pd_indexes_reindex_overload(self, target, method=None, level=None, limit=Non
         # build a dict of 'self' index values to their positions:
         map_index_to_position = Dict.empty(
             key_type=index_dtype,
-            value_type=types.int32
+            value_type=types.int64
         )
 
-        # TO-DO: needs concurrent hash map
+        # TO-DO: apply ConcurrentDict after it's perf is optimized
         for i, value in enumerate(self):
-            if value in map_index_to_position:
-                raise ValueError("cannot reindex from a duplicate axis")
-            else:
-                map_index_to_position[value] = i
+            map_index_to_position[value] = i
+
+        if len(map_index_to_position) < len(self):
+            raise ValueError("cannot reindex from a duplicate axis")
 
         res_size = len(target)
         indexer = np.empty(res_size, dtype=np.int64)
         for i in numba.prange(res_size):
-            val = target[i]
-            if val in map_index_to_position:
-                indexer[i] = map_index_to_position[val]
-            else:
-                indexer[i] = -1
+            indexer[i] = map_index_to_position.get(target[i], -1)
 
         return target, indexer
 

--- a/sdc/extensions/indexes/int64_index_ext.py
+++ b/sdc/extensions/indexes/int64_index_ext.py
@@ -52,6 +52,7 @@ from sdc.functions import numpy_like
 from sdc.hiframes.api import fix_df_index
 from sdc.extensions.indexes.indexes_generic import *
 from sdc.datatypes.common_functions import hpat_arrays_append
+from sdc.extensions.sdc_hashmap_ext import map_and_fill_indexer_int64
 
 
 @intrinsic
@@ -456,7 +457,14 @@ def pd_int64_index_reindex_overload(self, target, method=None, level=None, limit
         Given: self={}, target={}'.format(_func_name, self, target))
 
     def pd_int64_index_reindex_impl(self, target, method=None, level=None, limit=None, tolerance=None):
-        return sdc_indexes_reindex(self, target=target, method=method, level=level, tolerance=tolerance)
+        # for Int64Index case index.data can be passed to native function that can built the map
+        # and fill the resulting indexer more efficiently than generic implementation
+        indexer = np.empty(len(target), dtype=np.int64)
+        ok = map_and_fill_indexer_int64(self.values, target, indexer)
+        if not ok:
+            raise ValueError("cannot reindex from a duplicate axis")
+
+        return target, indexer
 
     return pd_int64_index_reindex_impl
 

--- a/sdc/extensions/indexes/int64_index_ext.py
+++ b/sdc/extensions/indexes/int64_index_ext.py
@@ -456,6 +456,7 @@ def pd_int64_index_reindex_overload(self, target, method=None, level=None, limit
         raise TypingError('{} Not allowed for non comparable indexes. \
         Given: self={}, target={}'.format(_func_name, self, target))
 
+    # FIXME: handle case when target is not numpy array!
     def pd_int64_index_reindex_impl(self, target, method=None, level=None, limit=None, tolerance=None):
         # for Int64Index case index.data can be passed to native function that can built the map
         # and fill the resulting indexer more efficiently than generic implementation

--- a/sdc/extensions/sdc_hashmap_ext.py
+++ b/sdc/extensions/sdc_hashmap_ext.py
@@ -1153,7 +1153,14 @@ def map_and_fill_indexer_int64(typingctx, index_data_type, searched_type, res_ty
         res_ctinfo = context.make_helper(builder, res_type, res_val)
         lir_key_type = context.get_value_type(types.int64)
 
-        size_val = context.compile_internal(
+        data_size_val = context.compile_internal(
+            builder,
+            lambda arr: len(arr),
+            types.int64(index_data_type),
+            [data_val]
+        )
+
+        searched_size_val = context.compile_internal(
             builder,
             lambda arr: len(arr),
             types.int64(searched_type),
@@ -1164,6 +1171,7 @@ def map_and_fill_indexer_int64(typingctx, index_data_type, searched_type, res_ty
                                 [lir_key_type.as_pointer(),
                                  lir_key_type.as_pointer(),
                                  lir.IntType(64),
+                                 lir.IntType(64),
                                  lir_key_type.as_pointer(),])
         fn_hashmap_fill_indexer = builder.module.get_or_insert_function(
             fnty, name=f"native_map_and_fill_indexer_int64")
@@ -1171,7 +1179,8 @@ def map_and_fill_indexer_int64(typingctx, index_data_type, searched_type, res_ty
         res = builder.call(fn_hashmap_fill_indexer,
                            [data_ctinfo.data,
                             searched_ctinfo.data,
-                            size_val,
+                            data_size_val,
+                            searched_size_val,
                             res_ctinfo.data])
         return context.cast(builder, res, types.uint8, types.bool_)
 


### PR DESCRIPTION
Motivation: current implementation of Int64Index reindex via building map_positions as a typed.Dict and filling the result indexer in a prange scales poorly and has performance that is far from ideal. This PR improves performance by ~2x by using native TBB based implementation. 