### PR TITLE
Allow global values to be used in read_csv params (names, usecols)

### DIFF
--- a/sdc/rewrites/read_csv_consts.py
+++ b/sdc/rewrites/read_csv_consts.py
@@ -63,7 +63,7 @@ class RewriteReadCsv(Rewrite):
                 if key in self._read_csv_const_args:
                     arg_def = guard(get_definition, func_ir, var)
                     ops = ['build_list', 'build_set', 'build_map']
-                    if arg_def.op in ops:
+                    if isinstance(arg_def, ir.Expr) and arg_def.op in ops:
                         args.append(arg_def)
 
         return len(args) > 0

--- a/sdc/tests/test_io.py
+++ b/sdc/tests/test_io.py
@@ -398,6 +398,26 @@ class TestCSV(TestIO):
         sdc_func = self.jit(test_impl)
         pd.testing.assert_frame_equal(sdc_func(), test_impl())
 
+    def test_csv_infer_file_param_names_no_rewrite(self):
+        """Test verifies pandas read_csv impl supports names parameters as tuple of columns
+           both captured as global or local variable """
+
+        def test_impl_1():
+            const_names = ('A', 'B', 'C', 'D')
+            return pd.read_csv("csv_data_date1.csv",
+                               names=const_names)
+
+        global_csv_names = ('A', 'B', 'C', 'D')
+
+        def test_impl_2():
+            return pd.read_csv("csv_data_date1.csv",
+                               names=global_csv_names)
+
+        for test_impl in [test_impl_1, test_impl_2]:
+            with self.subTest(tested_func_name=test_impl.__name__):
+                sdc_func = self.jit(test_impl)
+                pd.testing.assert_frame_equal(sdc_func(), test_impl())
+
     def test_csv_infer_file_param_converters_1(self):
         """Test verifies pandas read_csv impl supports conversion of all columns using converters parameter"""
 


### PR DESCRIPTION
Motivation: fixes a bug in RewriteReadCsv rewrite that fails compilation
when exception is raised during the match phase because variable
defining value of read_csv parameter is not ir.Expr node but ir.Global
(and thus has no op attribute).