### PR TITLE
add dataframe apply

### DIFF
--- a/sdc/datatypes/hpat_pandas_dataframe_functions.py
+++ b/sdc/datatypes/hpat_pandas_dataframe_functions.py
@@ -33,7 +33,6 @@ import numba
 import numpy
 import operator
 import pandas
-
 import sdc
 
 from pandas.core.indexing import IndexingError

--- a/sdc/datatypes/hpat_pandas_dataframe_functions.py
+++ b/sdc/datatypes/hpat_pandas_dataframe_functions.py
@@ -32,12 +32,9 @@
 import numba
 import numpy
 import operator
-
-import numpy as np
 import pandas
 from numba.core.target_extension import resolve_dispatcher_from_str, \
     current_target
-
 import sdc
 
 from pandas.core.indexing import IndexingError
@@ -3520,7 +3517,7 @@ def pd_dataframe_apply_overload(self, func, axis=0, raw=False, result_type=None,
         # allocate memory for func results in advance for parallel range
         lst_col = []
         for _ in range(col_len):
-            lst_col.append(np.empty(row_len))
+            lst_col.append(numpy.empty(row_len))
 
         for row_inx in prange(row_len):
             func_arr = func(self.iloc[row_inx], *other_args, last_arg).values

--- a/sdc/datatypes/hpat_pandas_dataframe_functions.py
+++ b/sdc/datatypes/hpat_pandas_dataframe_functions.py
@@ -33,8 +33,7 @@ import numba
 import numpy
 import operator
 import pandas
-from numba.core.target_extension import resolve_dispatcher_from_str, \
-    current_target
+
 import sdc
 
 from pandas.core.indexing import IndexingError
@@ -45,6 +44,10 @@ from numba.typed import List, Dict
 from numba.core.errors import TypingError
 from numba.core.registry import cpu_target
 from pandas.core.indexing import IndexingError
+from numba.core.target_extension import (
+    resolve_dispatcher_from_str,
+    current_target
+)
 
 from sdc.datatypes.indexes import *
 from sdc.hiframes.pd_dataframe_ext import DataFrameType

--- a/sdc/tests/test_dataframe.py
+++ b/sdc/tests/test_dataframe.py
@@ -2995,19 +2995,18 @@ class TestDataFrame(TestCase):
 
     def test_df_apply_row_wise(self):
         def func(series, arg1, arg2):
-            arg2_lst = ['a', 'b']
-            return pd.Series(np.array([.1, .2]), index=arg2_lst)
+            arg2_lst = [val for val in arg2]
+            return pd.Series(np.array([.1*arg1, .2]), index=arg2_lst)
 
         @self.jit
         def _test_apply(df, func, args):
             return df.apply(func, args=args)
 
         df = pd.DataFrame(np.arange(15).reshape(5, 3), columns=['A', 'B', 'C'])
-        print(df)
+        df2 = df.apply(func, axis=1, args=(0, ('c1', 'c2')))
         jit_func = self.jit()(func)
-        print(jit_func(None, None, None))
-        jit_df = _test_apply(df, jit_func, (0, ('a', 'b')))
-        print(jit_df)
+        jit_df = _test_apply(df, jit_func, (0, ('c1', 'c2')))
+        pd.testing.assert_frame_equal(df2, jit_df)
 
 
 if __name__ == "__main__":

--- a/sdc/tests/test_dataframe.py
+++ b/sdc/tests/test_dataframe.py
@@ -3002,7 +3002,7 @@ class TestDataFrame(TestCase):
         def _test_apply(df, func, args):
             return df.apply(func, args=args)
 
-        df = pd.DataFrame(np.arange(15).reshape(5, 3))#, columns=['A','B','C'])
+        df = pd.DataFrame(np.arange(15).reshape(5, 3), columns=['A', 'B', 'C'])
         print(df)
         jit_func = self.jit()(func)
         print(jit_func(None, None, None))

--- a/sdc/tests/test_dataframe.py
+++ b/sdc/tests/test_dataframe.py
@@ -2994,26 +2994,20 @@ class TestDataFrame(TestCase):
         np.testing.assert_array_equal(result, expected)
 
     def test_df_apply_row_wise(self):
-        @self.jit
-        def user_function(series, arg1, arg2, real_col_names):
-            col_names_lst = [val for val in real_col_names]
+        def func(series, arg1, arg2):
+            col_names_lst = ['a', 'b']
             return pd.Series(np.array([.1, .2]), index=col_names_lst)
 
         @self.jit
-        def _test_apply(df, udf, args, names):
-            return df.apply(udf, args, names)
+        def _test_apply(df, func, args):
+            return df.apply(func, args=args)
 
-        data = pd.DataFrame(
-            {'A': np.zeros(10), 'B': np.ones(10), 'C': np.random.randn(10)}
-        )
-        real_col_names = ('A', 'B')
-        expected_df = pd.DataFrame(
-            {'A': [.1 for _ in range(10)], 'B': [.2 for _ in range(10)]}
-        )
-        jit_df = _test_apply(data, user_function, (np.nan, 0.2), real_col_names)
-        np.testing.assert_array_equal(expected_df.to_numpy(), jit_df.to_numpy())
-        # dataframe testing cannot pass
-        # pd.testing.assert_frame_equal(expected_df, jit_df)
+        df = pd.DataFrame(np.arange(15).reshape(5, 3))#, columns=['A','B','C'])
+        print(df)
+        jit_func = self.jit()(func)
+        print(jit_func(None, None, None))
+        jit_df = _test_apply(df, jit_func, (0, 2))
+        print(jit_df)
 
 
 if __name__ == "__main__":

--- a/sdc/tests/test_dataframe.py
+++ b/sdc/tests/test_dataframe.py
@@ -2995,7 +2995,7 @@ class TestDataFrame(TestCase):
 
     def test_df_apply_row_wise(self):
         def func(series, arg1, arg2):
-            arg2_lst = ['a' , 'b']
+            arg2_lst = ['a', 'b']
             return pd.Series(np.array([.1, .2]), index=arg2_lst)
 
         @self.jit

--- a/sdc/tests/test_dataframe.py
+++ b/sdc/tests/test_dataframe.py
@@ -2995,8 +2995,8 @@ class TestDataFrame(TestCase):
 
     def test_df_apply_row_wise(self):
         def func(series, arg1, arg2):
-            col_names_lst = ['a', 'b']
-            return pd.Series(np.array([.1, .2]), index=col_names_lst)
+            arg2_lst = ['a' , 'b']
+            return pd.Series(np.array([.1, .2]), index=arg2_lst)
 
         @self.jit
         def _test_apply(df, func, args):
@@ -3006,7 +3006,7 @@ class TestDataFrame(TestCase):
         print(df)
         jit_func = self.jit()(func)
         print(jit_func(None, None, None))
-        jit_df = _test_apply(df, jit_func, (0, 2))
+        jit_df = _test_apply(df, jit_func, (0, ('a', 'b')))
         print(jit_df)
 
 


### PR DESCRIPTION
I implmented a limited version of `pandas.DataFrame.apply`, which can allow `axis=1` and elements of output dataframe are all `types.float64`, which can accelerate apply api by `5-10x` in single core, by `20-30x` in eight cores.

Actually, my implementation has some limitations (some from sdc, some from numba, some from my own):

1. `args[-1]` must be a `tuple`, and its `length` must be the same with the `length` of output dataframe columns. Besides, I want to use the value of `args[-1]` as the output dataframe column names, but I don't figure out a way to implement this idea, instead I have to generate a list named `col_names` to use in `DataFrameType` init
2. right now, my implementation unsupports `kwargs` used in origin `pandas.DataFrame.apply`
3. right now I assume `axis=1`, `raw=False`, `result_type=None`, which could be enhanced later
4. Related with limitation `1`, I want to move `DataFrameType` init code into `impl` body for using the `args[-1]` value, but `get_structure_maps` cannot move into impl, since not jitted, any idea about it?
5. right now, I assume `func` returns `Series` type, which could be enhanced later too, e.g., allow `list` or `np.ndarray` type.
6. Last but not the least, I want users who use compiled `apply` can provide the each colunmn's `type` information of output dataframe, e.g., all `types.float64`, `types.string`, even mixed: the 1st column with `types.float64`, the other colunmns with `types.string`, but how to implement it? Any suggestion? Now, I only implement a version of all output types are`typesss.float64`.

Any comments are welcome! Thanks! @kozlov-alexey @shssf 